### PR TITLE
tests/macos_smoke: push real packet through utun, drop redundant test

### DIFF
--- a/crates/tincd/tests/macos_smoke.rs
+++ b/crates/tincd/tests/macos_smoke.rs
@@ -1,8 +1,20 @@
-//! macOS smoke test: daemon start → utun open → SIGTERM → clean shutdown.
+//! macOS real-utun smoke test.
 //!
-//! utun requires root. The cargo test runner (`scripts/macos-test-runner.sh`)
-//! re-execs under sudo when passwordless sudo is available. Without it,
-//! the test prints SKIP and passes.
+//! `two_daemons/*` runs on macOS but uses `DeviceType=fd` socketpair
+//! — the `BsdTun` Utun read/write arms never execute. macOS has no
+//! netns, so two real utuns would fight over one routing table; the
+//! single-daemon unreachable path (mirrors
+//! `netns/ping.rs::real_tun_unreachable`) still proves both halves:
+//!
+//!   - **read**: kernel writes `[4-byte AF prefix][IP]` at +10;
+//!     nibble→ethertype synth; `route()` dispatches v4.
+//!   - **write**: ethertype→`htonl(AF_INET)` prefix, write at +10.
+//!     Kernel ICMP rcv is strict — bad checksum/prefix/quoted-hdr
+//!     → silent drop → ping just says "100% packet loss". Ping
+//!     printing the unreachable means the wire is correct.
+//!
+//! utun needs root; `scripts/macos-test-runner.sh` re-execs under
+//! sudo when cached. Otherwise: SKIP.
 
 #![cfg(target_os = "macos")]
 
@@ -10,64 +22,102 @@
 mod common;
 
 use common::*;
-use std::process::Stdio;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
 
-/// Write minimal utun config. `Interface = utun99` to avoid conflicts.
+/// High unit number to dodge VPN clients / leftover devices.
+const IFACE: &str = "utun200";
+
 fn write_utun_config(confbase: &std::path::Path) {
     std::fs::create_dir_all(confbase.join("hosts")).unwrap();
     std::fs::write(
         confbase.join("tinc.conf"),
-        "Name = smoketest\n\
-         DeviceType = tun\n\
-         AddressFamily = ipv4\n\
-         Interface = utun99\n",
+        format!(
+            "Name = smoketest\n\
+             DeviceType = tun\n\
+             AddressFamily = ipv4\n\
+             Interface = {IFACE}\n"
+        ),
     )
     .unwrap();
-    std::fs::write(confbase.join("hosts").join("smoketest"), "Port = 0\n").unwrap();
-    let seed = [0xAA; 32];
-    write_ed25519_privkey(confbase, &seed);
+    // Own /32 only; the p2p peer (10.88.0.2) is unowned → route()
+    // returns Unreachable.
+    std::fs::write(
+        confbase.join("hosts").join("smoketest"),
+        "Port = 0\nSubnet = 10.88.0.1/32\n",
+    )
+    .unwrap();
+    write_ed25519_privkey(confbase, &[0xAA; 32]);
 }
 
 #[test]
-fn utun_start_sigterm_shutdown() {
+fn utun_icmp_unreachable() {
     if !nix::unistd::geteuid().is_root() {
-        eprintln!("SKIP: utun smoke test requires root (no passwordless sudo)");
+        eprintln!("SKIP: utun_icmp_unreachable requires root");
         return;
     }
 
-    let tmp = TmpGuard::new("macos-smoke", "utun");
+    let tmp = TmpGuard::new("macos-smoke", "unreach");
     let (confbase, pidfile, socket) = tmp.std_paths();
-
     write_utun_config(&confbase);
 
+    // `tincd::net=debug` for the "unreachable, sending ICMP" line.
     let mut child = tincd_at(&confbase, &pidfile, &socket)
-        .env("RUST_LOG", "tincd=info")
+        .env("RUST_LOG", "tincd=info,tincd::net=debug")
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn tincd");
 
     assert!(
         wait_for_file(&socket),
-        "tincd didn't start; stderr: {}",
+        "tincd didn't start; stderr:\n{}",
         drain_stderr(child)
     );
 
-    // Verify utun99 exists via ifconfig
-    let ifconfig = std::process::Command::new("ifconfig")
-        .arg("utun99")
+    // p2p config installs a host route for 10.88.0.2 via utun200.
+    // No tinc-up script — inline so failures show ifconfig stderr.
+    let ifc = Command::new("ifconfig")
+        .args([IFACE, "10.88.0.1", "10.88.0.2", "up"])
         .output()
-        .expect("ifconfig");
+        .expect("spawn ifconfig");
     assert!(
-        ifconfig.status.success(),
-        "utun99 not found after daemon start; ifconfig stderr: {}",
-        String::from_utf8_lossy(&ifconfig.stderr)
+        ifc.status.success(),
+        "ifconfig {IFACE} failed (device not opened?); stderr: {}\n\
+         daemon stderr:\n{}",
+        String::from_utf8_lossy(&ifc.stderr),
+        drain_stderr(child)
     );
 
-    // SIGTERM → clean shutdown
+    // `-t 2` = macOS ping wall-clock deadline (TTL is `-m`). One
+    // echo is enough; the ICMP error is synchronous.
+    let ping = Command::new("ping")
+        .args(["-c", "1", "-t", "2", "10.88.0.2"])
+        .output()
+        .expect("spawn ping");
+
+    let stdout = String::from_utf8_lossy(&ping.stdout);
+    let stderr = String::from_utf8_lossy(&ping.stderr);
+    eprintln!("ping stdout:\n{stdout}\nping stderr:\n{stderr}");
+
+    assert!(
+        !ping.status.success(),
+        "ping should fail (no node owns 10.88.0.2); stdout: {stdout}"
+    );
+    // Kernel parsed our ICMP and matched it to ping's socket.
+    // Without correct AF prefix / checksum this never appears.
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("nreachable") || combined.contains("Unknown"),
+        "ping should surface the synthesized ICMP error \
+         (proves utun write path); got:\n{combined}\n\
+         daemon stderr:\n{}",
+        drain_stderr(child)
+    );
+
+    // SIGTERM → clean shutdown after real traffic.
     #[allow(clippy::cast_possible_wrap)]
     let pid = Pid::from_raw(child.id() as i32);
     kill(pid, Signal::SIGTERM).expect("kill SIGTERM");
@@ -80,6 +130,13 @@ fn utun_start_sigterm_shutdown() {
         assert!(Instant::now() < deadline, "tincd didn't exit on SIGTERM");
         std::thread::sleep(Duration::from_millis(10));
     };
+    let out = child.wait_with_output().unwrap();
+    let daemon_stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        daemon_stderr.contains("unreachable, sending ICMP"),
+        "daemon should log the ICMP synth (proves utun read path); stderr:\n{daemon_stderr}"
+    );
     assert!(status.success(), "tincd exit status: {status:?}");
     assert!(!pidfile.exists(), "pidfile should be cleaned up");
     assert!(!socket.exists(), "socket should be cleaned up");


### PR DESCRIPTION
The old test only proved open_utun() returned (ifconfig sees the device) and SIGTERM cleaned up. It never read or wrote a byte; the BsdTun Utun read/write arms had zero macOS coverage (two_daemons uses DeviceType=fd).

Replace with the single-daemon ICMP-unreachable trick from netns/ping.rs::real_tun_unreachable: ping the unowned p2p peer, daemon reads the echo off the utun, route() synths an ICMP error, daemon writes it back. macOS ping printing "Net Unreachable" means the kernel accepted our AF prefix + checksums — strict parser, silent drop otherwise. Keeps the SIGTERM/cleanup assertions, so the old test is a strict subset.