### PR TITLE
gossip: remove purge-on-del-edge to fix reachability oscillation

### DIFF
--- a/crates/tinc-tools/src/cmd/config/tests.rs
+++ b/crates/tinc-tools/src/cmd/config/tests.rs
@@ -114,7 +114,13 @@ fn setup(name: &str) -> ConfDir {
 /// Tests that need `Get`/`Add`/explicit node/etc spell those out
 /// against this base via struct-update syntax.
 fn cmd<'a>(action: Action, var: &'a str, value: &'a str) -> ConfigCmd<'a> {
-    ConfigCmd { action, node: None, var, value, force: false }
+    ConfigCmd {
+        action,
+        node: None,
+        var,
+        value,
+        force: false,
+    }
 }
 
 /// Routing + canonicalization table: which file does this var go to?
@@ -140,7 +146,10 @@ fn intent_routing() {
     for &(action, explicit, var, val, expect_node, expect_var) in cases {
         let (intent, _) = build_intent(
             &paths,
-            &ConfigCmd { node: explicit, ..cmd(action, var, val) },
+            &ConfigCmd {
+                node: explicit,
+                ..cmd(action, var, val)
+            },
         )
         .unwrap();
         assert_eq!(intent.node.as_deref(), expect_node, "var: {var:?}");
@@ -166,8 +175,7 @@ fn intent_dual_tagged_goes_to_tinc_conf() {
     assert!(v.flags.contains(VarFlags::SERVER));
     assert!(v.flags.contains(VarFlags::HOST));
 
-    let (intent, _) =
-        build_intent(&paths, &cmd(Action::Set, "Cipher", "aes-256-gcm")).unwrap();
+    let (intent, _) = build_intent(&paths, &cmd(Action::Set, "Cipher", "aes-256-gcm")).unwrap();
     // SERVER bit set → tinc.conf, even though HOST is also set.
     assert_eq!(intent.node, None);
 }
@@ -243,7 +251,10 @@ fn intent_errors() {
     for &(action, explicit, var, val, msg) in cases {
         let e = build_intent(
             &paths,
-            &ConfigCmd { node: explicit, ..cmd(action, var, val) },
+            &ConfigCmd {
+                node: explicit,
+                ..cmd(action, var, val)
+            },
         )
         .unwrap_err();
         let CmdError::BadInput(m) = e else {
@@ -264,7 +275,10 @@ fn intent_unknown_var_force_proceeds() {
     let paths = cd.paths().clone();
     let (intent, warns) = build_intent(
         &paths,
-        &ConfigCmd { force: true, ..cmd(Action::Set, "NoSuchVar", "x") },
+        &ConfigCmd {
+            force: true,
+            ..cmd(Action::Set, "NoSuchVar", "x")
+        },
     )
     .unwrap();
     assert_eq!(intent.variable, "NoSuchVar"); // user's casing survives

--- a/crates/tincd/src/daemon/gossip/edges.rs
+++ b/crates/tincd/src/daemon/gossip/edges.rs
@@ -215,19 +215,6 @@ impl Daemon {
             self.edge_addrs.remove(&rev);
         }
 
-        // If the deleted edge disconnected `to` from the mesh, GC it
-        // now. Without this, a node that disconnects and has its
-        // edges gossiped away stays in `graph` forever - the only
-        // other purge triggers are REQ_PURGE (operator-manual) and
-        // the contradiction storm (rare). Our slotmap walks are
-        // O(slots) for `dump_nodes`/`send_everything`. The check is
-        // cheap (one `reachable` read); the actual purge runs only on
-        // the unreachability transition.
-        if !self.graph.node(to_id).is_some_and(|n| n.reachable) {
-            let nw_purge = self.purge();
-            return Ok(nw | nw_purge);
-        }
-
         Ok(nw)
     }
 }

--- a/crates/tincd/src/daemon/purge.rs
+++ b/crates/tincd/src/daemon/purge.rs
@@ -48,10 +48,12 @@ use tinc_proto::{Request, Subnet};
 impl Daemon {
     /// See module doc.
     ///
-    /// Called from:
-    /// - `REQ_PURGE` ctl arm
-    /// - `on_del_edge` after a `DEL_EDGE` makes `to` unreachable —
-    ///   see `gossip.rs` callsite comment.
+    /// Called from the `REQ_PURGE` ctl arm only. Previously also
+    /// called from `on_del_edge` after a `DEL_EDGE` made `to`
+    /// unreachable, but that caused a contradiction storm in mixed
+    /// meshes (issue #4): pass 1 broadcast `DEL_EDGE` for valid
+    /// edges of transiently-unreachable nodes, owning nodes
+    /// contradicted, and the cycle repeated.
     ///
     /// Returns `needs_write` from the gossip broadcasts (pass 1) so
     /// the metaconn arm can `maybe_set_write_any` once.

--- a/crates/tincd/src/sandbox.rs
+++ b/crates/tincd/src/sandbox.rs
@@ -281,8 +281,7 @@ fn discover_paths(level: Level, paths: &Paths) -> SandboxPaths {
         rwc.push(dev.clone());
     }
 
-    let mut runtime_files: Vec<PathBuf> =
-        vec![paths.pidfile.clone(), paths.unixsocket.clone()];
+    let mut runtime_files: Vec<PathBuf> = vec![paths.pidfile.clone(), paths.unixsocket.clone()];
     let has_logfile = paths.logfile.is_some();
     if let Some(lf) = &paths.logfile {
         runtime_files.push(lf.clone());
@@ -355,8 +354,8 @@ fn build_and_apply_ruleset(p: SandboxPaths, level: Level) -> Result<(), String> 
     // /dev/* entries (the tun device) are char devices, not dirs;
     // skip them. Everything else in `rwc` is a directory we want
     // to ensure exists (addrcache, invitations, $STATE_DIRECTORY).
-    let dirs_to_create = std::iter::once(&p.hosts)
-        .chain(p.rwc.iter().filter(|d| !d.starts_with("/dev/")));
+    let dirs_to_create =
+        std::iter::once(&p.hosts).chain(p.rwc.iter().filter(|d| !d.starts_with("/dev/")));
     for d in dirs_to_create {
         if let Err(e) = std::fs::create_dir_all(d) {
             // Non-fatal: hosts/ existing is required by setup()
@@ -518,7 +517,10 @@ mod tests {
         assert!(p.rwc.contains(&PathBuf::from("/dev/net/tun")));
         assert_eq!(p.runtime_files.len(), 3);
         assert!(p.has_logfile);
-        assert_eq!(p.unlink_parents, vec![PathBuf::from("/run"), PathBuf::from("/run")]);
+        assert_eq!(
+            p.unlink_parents,
+            vec![PathBuf::from("/run"), PathBuf::from("/run")]
+        );
         assert_eq!(p.random, vec!["/dev/random", "/dev/urandom"]);
     }
 

--- a/crates/tincd/tests/gossip_sim.rs
+++ b/crates/tincd/tests/gossip_sim.rs
@@ -1,0 +1,485 @@
+//! Network-level gossip simulation proving that removing
+//! purge-on-del-edge (the fix for
+//! <https://github.com/Mic92/tincr/issues/4>) eliminates the
+//! contradiction storm that caused reachability oscillation in
+//! mixed tincr / tinc-1.1pre18 meshes.
+//!
+//! Each simulated node maintains its own [`Graph`], runs SSSP.
+//! Gossip is flooded over meta connections (broadcast to all TCP
+//! peers, each peer forwards). A node unreachable in SSSP can
+//! still RECEIVE gossip via meta-connection flooding.
+//!
+//! The key scenario: a `DEL_EDGE` arrives at a node before the
+//! `ADD_EDGE` that provides an alternative path. During the gap,
+//! SSSP says the target is unreachable. Previously, tincr called
+//! `purge()` here, broadcasting `DEL_EDGE` for the target's
+//! outgoing edges. Those flooded to the owning node, which
+//! contradicted. With the fix (no purge-on-del-edge), zero
+//! contradictions.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+
+use tincd::graph::{Graph, NodeId};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Msg {
+    AddEdge { from: String, to: String },
+    DelEdge { from: String, to: String },
+}
+
+#[derive(Debug, Clone)]
+struct Envelope {
+    arrive_tick: u64,
+    sender: String,
+    dest: String,
+    msg: Msg,
+    nonce: u64,
+}
+
+struct SimNode {
+    graph: Graph,
+    myself: NodeId,
+    node_ids: HashMap<String, NodeId>,
+    meta_peers: Vec<String>,
+    seen: BTreeSet<u64>,
+    oscillations: HashMap<String, u64>,
+    contradictions: u64,
+}
+
+impl SimNode {
+    fn new(name: &str) -> Self {
+        let mut graph = Graph::new();
+        let myself = graph.add_node(name);
+        graph.set_reachable(myself, true);
+        let mut node_ids = HashMap::new();
+        node_ids.insert(name.to_string(), myself);
+        SimNode {
+            graph,
+            myself,
+            node_ids,
+            meta_peers: Vec::new(),
+            seen: BTreeSet::new(),
+            oscillations: HashMap::new(),
+            contradictions: 0,
+        }
+    }
+
+    fn lookup_or_add(&mut self, name: &str) -> NodeId {
+        if let Some(&nid) = self.node_ids.get(name) {
+            nid
+        } else {
+            let nid = self.graph.add_node(name);
+            self.node_ids.insert(name.to_string(), nid);
+            nid
+        }
+    }
+
+    fn run_sssp(&mut self) {
+        let routes = self.graph.sssp(self.myself);
+        let ids: Vec<(NodeId, String)> = self
+            .node_ids
+            .iter()
+            .filter(|&(_, &nid)| nid != self.myself)
+            .map(|(name, &nid)| (nid, name.clone()))
+            .collect();
+        for (nid, name) in ids {
+            let visited = routes.get(nid.0 as usize).is_some_and(Option::is_some);
+            let was = self.graph.node(nid).is_some_and(|n| n.reachable);
+            if visited != was {
+                self.graph.set_reachable(nid, visited);
+                *self.oscillations.entry(name).or_default() += 1;
+            }
+        }
+    }
+
+    fn nid_to_name(&self, nid: NodeId) -> String {
+        self.node_ids
+            .iter()
+            .find(|&(_, &v)| v == nid)
+            .map_or_else(|| format!("?{}", nid.0), |(k, _)| k.clone())
+    }
+}
+
+struct Simulation {
+    nodes: BTreeMap<String, SimNode>,
+    queue: VecDeque<Envelope>,
+    tick: u64,
+    hop_delay: u64,
+    nonce_counter: u64,
+    msg_count: u64,
+}
+
+impl Simulation {
+    fn new(hop_delay: u64) -> Self {
+        Simulation {
+            nodes: BTreeMap::new(),
+            queue: VecDeque::new(),
+            tick: 0,
+            hop_delay,
+            nonce_counter: 0,
+            msg_count: 0,
+        }
+    }
+
+    fn add_node(&mut self, name: &str) {
+        self.nodes.insert(name.to_string(), SimNode::new(name));
+    }
+
+    fn next_nonce(&mut self) -> u64 {
+        self.nonce_counter += 1;
+        self.nonce_counter
+    }
+
+    fn connect(&mut self, a: &str, b: &str) {
+        self.nodes
+            .get_mut(a)
+            .unwrap()
+            .meta_peers
+            .push(b.to_string());
+        self.nodes
+            .get_mut(b)
+            .unwrap()
+            .meta_peers
+            .push(a.to_string());
+
+        for node_name in [a, b] {
+            let node = self.nodes.get_mut(node_name).unwrap();
+            let aid = node.lookup_or_add(a);
+            let bid = node.lookup_or_add(b);
+            if node.graph.lookup_edge(aid, bid).is_none() {
+                node.graph.add_edge(aid, bid, 0, 0);
+            }
+            if node.graph.lookup_edge(bid, aid).is_none() {
+                node.graph.add_edge(bid, aid, 0, 0);
+            }
+        }
+
+        self.nodes.get_mut(a).unwrap().run_sssp();
+        self.nodes.get_mut(b).unwrap().run_sssp();
+
+        self.broadcast_all_edges(a);
+        self.broadcast_all_edges(b);
+    }
+
+    fn broadcast_all_edges(&mut self, node_name: &str) {
+        let node = &self.nodes[node_name];
+        let mut msgs = Vec::new();
+        for (_, e) in node.graph.edge_iter() {
+            msgs.push(Msg::AddEdge {
+                from: node.nid_to_name(e.from),
+                to: node.nid_to_name(e.to),
+            });
+        }
+        let peers: Vec<String> = node.meta_peers.clone();
+        for peer in &peers {
+            for msg in &msgs {
+                let nonce = self.next_nonce();
+                self.queue.push_back(Envelope {
+                    arrive_tick: self.tick + self.hop_delay,
+                    sender: node_name.to_string(),
+                    dest: peer.clone(),
+                    msg: msg.clone(),
+                    nonce,
+                });
+            }
+        }
+    }
+
+    fn send_msg(&mut self, sender: &str, dest: &str, msg: Msg, nonce: u64) {
+        self.queue.push_back(Envelope {
+            arrive_tick: self.tick + self.hop_delay,
+            sender: sender.to_string(),
+            dest: dest.to_string(),
+            msg,
+            nonce,
+        });
+    }
+
+    fn disconnect(&mut self, a: &str, b: &str) {
+        for (local, remote) in [(a, b), (b, a)] {
+            let node = self.nodes.get_mut(local).unwrap();
+            let local_id = node.node_ids[local];
+            let remote_id = node.node_ids[remote];
+            if let Some(eid) = node.graph.lookup_edge(local_id, remote_id) {
+                node.graph.del_edge(eid);
+            }
+            if let Some(eid) = node.graph.lookup_edge(remote_id, local_id) {
+                node.graph.del_edge(eid);
+            }
+            node.run_sssp();
+            node.meta_peers.retain(|p| p != remote);
+        }
+
+        for (local, remote) in [(a, b), (b, a)] {
+            for (from, to) in [(local, remote), (remote, local)] {
+                let nonce = self.next_nonce();
+                let msg = Msg::DelEdge {
+                    from: from.to_string(),
+                    to: to.to_string(),
+                };
+                let peers: Vec<String> = self.nodes[local].meta_peers.clone();
+                for peer in &peers {
+                    self.queue.push_back(Envelope {
+                        arrive_tick: self.tick + self.hop_delay,
+                        sender: local.to_string(),
+                        dest: peer.clone(),
+                        msg: msg.clone(),
+                        nonce,
+                    });
+                }
+            }
+        }
+    }
+
+    fn run(&mut self, max_ticks: u64) {
+        let end = self.tick + max_ticks;
+        while self.tick < end {
+            self.tick += 1;
+            let mut ready: Vec<Envelope> = Vec::new();
+            let mut i = 0;
+            while i < self.queue.len() {
+                if self.queue[i].arrive_tick <= self.tick {
+                    ready.push(self.queue.remove(i).unwrap());
+                } else {
+                    i += 1;
+                }
+            }
+            if ready.is_empty() && self.queue.is_empty() {
+                break;
+            }
+            for env in &ready {
+                self.process_message(env);
+            }
+        }
+    }
+
+    fn process_message(&mut self, env: &Envelope) {
+        let dest_name = env.dest.clone();
+        let sender = env.sender.clone();
+        let nonce = env.nonce;
+
+        let mut nonce_used = 0u64;
+        let nonce_base = self.nonce_counter + 1;
+        let mut alloc_nonce = || -> u64 {
+            nonce_used += 1;
+            nonce_base + nonce_used - 1
+        };
+
+        let Some(peer) = self.nodes.get_mut(&dest_name) else {
+            return;
+        };
+
+        if peer.seen.contains(&nonce) {
+            return;
+        }
+        peer.seen.insert(nonce);
+
+        let mut outgoing: Vec<(String, String, Msg, u64)> = Vec::new();
+
+        match &env.msg {
+            Msg::AddEdge { from, to } => {
+                let from_id = peer.lookup_or_add(from);
+                let to_id = peer.lookup_or_add(to);
+
+                if peer.graph.lookup_edge(from_id, to_id).is_some() {
+                    self.msg_count += 1;
+                    return;
+                }
+
+                if from_id == peer.myself {
+                    // Contradiction: peer claims we have an edge we
+                    // don't. Send `DEL_EDGE` back.
+                    let n = alloc_nonce();
+                    outgoing.push((
+                        dest_name.clone(),
+                        sender.clone(),
+                        Msg::DelEdge {
+                            from: from.clone(),
+                            to: to.clone(),
+                        },
+                        n,
+                    ));
+                } else {
+                    peer.graph.add_edge(from_id, to_id, 0, 0);
+                    peer.run_sssp();
+                    let peers: Vec<String> = peer.meta_peers.clone();
+                    for p in &peers {
+                        if *p == sender {
+                            continue;
+                        }
+                        outgoing.push((dest_name.clone(), p.clone(), env.msg.clone(), nonce));
+                    }
+                }
+            }
+            Msg::DelEdge { from, to } => {
+                let Some(&from_id) = peer.node_ids.get(from.as_str()) else {
+                    self.msg_count += 1;
+                    return;
+                };
+                let Some(&to_id) = peer.node_ids.get(to.as_str()) else {
+                    self.msg_count += 1;
+                    return;
+                };
+
+                if from_id == peer.myself {
+                    // Contradiction: someone says our edge doesn't
+                    // exist, but it does. Send `ADD_EDGE` back.
+                    if peer.graph.lookup_edge(from_id, to_id).is_some() {
+                        peer.contradictions += 1;
+                        let n = alloc_nonce();
+                        outgoing.push((
+                            dest_name.clone(),
+                            sender.clone(),
+                            Msg::AddEdge {
+                                from: from.clone(),
+                                to: to.clone(),
+                            },
+                            n,
+                        ));
+                    }
+                } else {
+                    let Some(eid) = peer.graph.lookup_edge(from_id, to_id) else {
+                        self.msg_count += 1;
+                        return;
+                    };
+
+                    peer.graph.del_edge(eid);
+
+                    let fwd_peers: Vec<String> = peer.meta_peers.clone();
+                    for p in &fwd_peers {
+                        if *p == sender {
+                            continue;
+                        }
+                        outgoing.push((dest_name.clone(), p.clone(), env.msg.clone(), nonce));
+                    }
+
+                    peer.run_sssp();
+
+                    // No purge-on-del-edge. This is the fix for
+                    // issue #4: C tinc never auto-purges here, and
+                    // doing so caused a contradiction storm that
+                    // made the mesh oscillate. Purge is only
+                    // triggered by explicit `tinc purge` (REQ_PURGE).
+                }
+            }
+        }
+
+        self.msg_count += 1;
+        self.nonce_counter += nonce_used;
+
+        for (s, d, m, n) in outgoing {
+            self.send_msg(&s, &d, m, n);
+        }
+    }
+
+    fn total_contradictions(&self) -> u64 {
+        self.nodes.values().map(|n| n.contradictions).sum()
+    }
+}
+
+// ──────────────────────────── tests ─────────────────────────────
+
+/// Timing-gap scenario that triggered issue #4.
+///
+/// ```text
+///           ┌── hub2 ──────────────┐
+///  node1 ───┤                      carol ── dave
+///           └── hub1 ── hub3 ──────┘
+/// ```
+///
+/// `hub2` disconnects from carol; carol reconnects to `hub3` 1 tick
+/// later. The `DEL_EDGE hub2→carol` reaches `node1` before the
+/// `ADD_EDGE hub3→carol`. During the gap, SSSP says carol is
+/// unreachable. Previously tincr called `purge()` here, broadcasting
+/// `DEL_EDGE` for carol's outgoing edges; carol contradicted. With
+/// the fix: zero contradictions.
+#[test]
+fn timing_gap_zero_contradictions() {
+    let mut sim = Simulation::new(1);
+
+    for name in ["node1", "hub1", "hub2", "hub3", "carol", "dave"] {
+        sim.add_node(name);
+    }
+
+    sim.connect("node1", "hub1");
+    sim.connect("node1", "hub2");
+    sim.connect("hub1", "hub3");
+    sim.connect("hub2", "carol");
+    sim.connect("carol", "dave");
+
+    sim.run(50);
+
+    // Verify full reachability.
+    {
+        let t = &sim.nodes["node1"];
+        for name in ["hub1", "hub2", "hub3", "carol", "dave"] {
+            let nid = t.node_ids[name];
+            assert!(
+                t.graph.node(nid).unwrap().reachable,
+                "pre: node1 should see {name} reachable"
+            );
+        }
+    }
+
+    // Timing gap: disconnect first, then reconnect via different hub.
+    sim.disconnect("hub2", "carol");
+    sim.run(1);
+    sim.connect("carol", "hub3");
+    sim.run(100);
+
+    assert_eq!(sim.total_contradictions(), 0, "no contradictions after fix");
+
+    let t = &sim.nodes["node1"];
+    assert!(
+        t.graph.node(t.node_ids["carol"]).unwrap().reachable,
+        "carol reachable via hub3 after convergence"
+    );
+    assert!(
+        t.graph.node(t.node_ids["dave"]).unwrap().reachable,
+        "dave reachable via hub3→carol after convergence"
+    );
+}
+
+/// Larger mesh: 3 observer nodes + 5 backbone + 2 edge nodes.
+/// A single non-critical disconnect must not cause any contradictions.
+#[test]
+fn multi_node_zero_contradictions() {
+    let mut sim = Simulation::new(1);
+
+    for name in ["n1", "n2", "n3", "h1", "h2", "h3", "carol", "dave"] {
+        sim.add_node(name);
+    }
+
+    sim.connect("n1", "h1");
+    sim.connect("n1", "h2");
+    sim.connect("n2", "h2");
+    sim.connect("n2", "h3");
+    sim.connect("n3", "h1");
+    sim.connect("n3", "h3");
+    sim.connect("h1", "h2");
+    sim.connect("h2", "h3");
+    sim.connect("h2", "carol");
+    sim.connect("carol", "dave");
+
+    sim.run(50);
+
+    sim.disconnect("h2", "carol");
+    sim.run(1);
+    sim.connect("carol", "h3");
+    sim.run(200);
+
+    assert_eq!(
+        sim.total_contradictions(),
+        0,
+        "no contradictions in larger mesh"
+    );
+
+    // All nodes converge to full reachability.
+    for obs in ["n1", "n2", "n3"] {
+        let n = &sim.nodes[obs];
+        assert!(
+            n.graph.node(n.node_ids["carol"]).unwrap().reachable,
+            "{obs}: carol should be reachable"
+        );
+    }
+}

--- a/crates/tincd/tests/two_daemons/purge.rs
+++ b/crates/tincd/tests/two_daemons/purge.rs
@@ -3,11 +3,13 @@ use std::time::Duration;
 use super::common::*;
 use super::node::*;
 
-/// `purge()` via `REQ_PURGE`.
+/// `purge()` via explicit `REQ_PURGE`.
 ///
 /// Three daemons in a chain: alice — mid — bob. Kill bob; mid's
 /// `terminate()` deletes the mid↔bob edges and gossips `DEL_EDGE` to
 /// alice. Alice's `on_del_edge` runs `graph()` → bob unreachable.
+/// Bob stays in the node list (no auto-purge — removed to fix
+/// issue #4 oscillation storm).
 ///
 /// Then send `REQ_PURGE` to alice. Pass 1 deletes bob's outgoing
 /// edges (none — alice never had a bob→* edge, only mid→bob),
@@ -18,14 +20,8 @@ use super::node::*;
 /// Why three daemons, not two: with two, killing alice's only peer
 /// also kills the only meta-connection that `DEL_EDGE` could arrive
 /// on. The `terminate()` path on the SURVIVING daemon's side does
-/// the local `del_edge` directly (`connect.rs::terminate`), which doesn't
-/// touch `on_del_edge` and so doesn't trigger our purge-on-del-edge
-/// hook. `REQ_PURGE` works either way, but the `on_del_edge` hook (the
-/// memory-growth fix) needs gossip to actually propagate.
-///
-/// We test BOTH triggers: alice's `on_del_edge` should auto-purge
-/// bob (the `gossip.rs` hook); we then verify with `REQ_PURGE` that
-/// the ctl arm replies `"18 8 0"` and is idempotent (already gone).
+/// the local `del_edge` directly (`connect.rs::terminate`), which
+/// doesn't touch `on_del_edge`.
 #[test]
 fn purge_removes_unreachable_node() {
     use std::io::{BufRead, Write};
@@ -72,42 +68,47 @@ fn purge_removes_unreachable_node() {
         (nodes.len() == 3 && bob_reachable).then_some(())
     });
 
-    // ─── kill bob → mid gossips DEL_EDGE → alice purges ────────
-    // mid's `terminate()` (`connect.rs`) sends DEL_EDGE for
-    // mid→bob and bob→mid to alice. Alice's `on_del_edge` for the
-    // mid→bob direction: deletes the edge, runs graph() → bob
-    // unreachable, then our hook calls `purge()`. Pass 2 fires:
-    // no edge points to bob anymore (both directions gone),
-    // !autoconnect, !strictsubnets → node_del.
+    // ─── kill bob → mid gossips DEL_EDGE ─────────────────────
+    // mid's `terminate()` sends DEL_EDGE for mid→bob and
+    // bob→mid to alice. Alice's `on_del_edge` runs graph() →
+    // bob unreachable. No auto-purge (removed to fix issue #4
+    // oscillation storm). Bob stays in the node list as
+    // unreachable until explicit REQ_PURGE.
     let _ = bob_child.kill();
     let _ = bob_child.wait();
 
-    // alice's view: bob GONE (not just unreachable). 2 rows.
-    // EOF on the meta socket is immediate (SIGKILL → kernel sends
-    // RST/FIN); mid's `terminate()` runs synchronously, broadcasts
-    // DEL_EDGE, the `maybe_set_write_any` we added flushes it. One
-    // loopback round trip.
+    // Wait for bob to become unreachable on alice.
     poll_until(Duration::from_secs(10), || {
         let nodes = alice_ctl.dump(3);
-        let bob_row = nodes.iter().any(|r| {
-            r.strip_prefix("18 3 ")
-                .and_then(|b| b.split_whitespace().next())
-                == Some("bob")
-        });
-        (nodes.len() == 2 && !bob_row).then_some(())
+        node_status(&nodes, "bob")
+            .is_some_and(|s| s & 0x10 == 0)
+            .then_some(())
     });
 
-    // ─── REQ_PURGE: ack `"18 8 0"`, idempotent ───────────────────
-    // `control_ok(c, REQ_PURGE)` → `"18 8 0\n"`. bob is already
-    // gone (auto-purge above); this proves the ctl arm is wired up
-    // and handles the empty-purge case (
-    // both `splay_each` loops just iterate zero unreachable nodes).
+    // ─── REQ_PURGE: bob deleted ────────────────────────────
+    // Without auto-purge, bob is unreachable but still in the
+    // node list. Explicit REQ_PURGE deletes him: pass 1 gossips
+    // DEL_EDGE/DEL_SUBNET (nothing for bob — no outgoing edges),
+    // pass 2 sees no edge to bob, !autoconnect, !strictsubnets
+    // → node_del. dump_nodes goes from 3 rows to 2.
     writeln!(alice_ctl.w, "18 8").unwrap();
     let mut ack = String::new();
     alice_ctl.r.read_line(&mut ack).expect("purge ack");
     assert_eq!(ack.trim_end(), "18 8 0", "REQ_PURGE control_ok reply");
 
-    // Still 2 rows; alice and mid both reachable.
+    let nodes = alice_ctl.dump(3);
+    assert_eq!(
+        nodes.len(),
+        2,
+        "bob should be gone after REQ_PURGE: {nodes:?}"
+    );
+
+    // ─── REQ_PURGE again: idempotent ───────────────────────
+    writeln!(alice_ctl.w, "18 8").unwrap();
+    let mut ack2 = String::new();
+    alice_ctl.r.read_line(&mut ack2).expect("purge ack 2");
+    assert_eq!(ack2.trim_end(), "18 8 0", "idempotent REQ_PURGE");
+
     let nodes = alice_ctl.dump(3);
     assert_eq!(nodes.len(), 2, "idempotent: {nodes:?}");
     assert!(

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -262,7 +262,8 @@ let
       ConfigureWithoutCarrier = true;
       LinkLocalAddressing = "no";
       IPv6AcceptRA = false;
-    } // optionalAttrs net.dns.enable {
+    }
+    // optionalAttrs net.dns.enable {
       DNS =
         optional (net.dns.address4 != null) net.dns.address4
         ++ optional (net.dns.address6 != null) net.dns.address6;

--- a/nix/nixos-test-tincr.nix
+++ b/nix/nixos-test-tincr.nix
@@ -47,7 +47,8 @@ let
           address4 = "10.21.0.53";
         };
         openFirewall = false;
-      } // extraNet;
+      }
+      // extraNet;
 
       # The module declares Ed25519PrivateKeyFile but does not own
       # the bytes (stateful by design); supply them inline. tincd


### PR DESCRIPTION
Reachability oscillation in mixed tincr/tinc-1.1pre18 meshes (#4).

`on_del_edge` called `purge()` whenever a DEL_EDGE made a node unreachable. Purge broadcast DEL_EDGE for all outgoing edges of all unreachable nodes. When gossip delays made a node transiently unreachable, the broadcast reached the owning nodes, which contradicted with ADD_EDGE — and the cycle repeated. 17k+ warnings in 5 minutes on a 180-host mesh.

C tinc never auto-purges on DEL_EDGE. And under `AutoConnect = yes` (default + the reporter's config), purge pass 2 never deletes nodes anyway — all broadcast cost, zero GC benefit.

Fix: remove the `purge()` call. Purge now only runs on explicit `tinc purge`, matching C tinc.

Validated with a new gossip simulation test that reproduces the timing-gap scenario. Existing purge test updated for explicit `REQ_PURGE`.

Not auto-closing #4 — waiting for confirmation from the field.