### PR TITLE
tincd/net: clear cached udp_addr on ENETUNREACH/EHOSTUNREACH

### DIFF
--- a/crates/tincd/src/daemon/net/device.rs
+++ b/crates/tincd/src/daemon/net/device.rs
@@ -2,10 +2,13 @@ use super::super::Daemon;
 use super::DEVICE_DRAIN_CAP;
 
 use std::io;
+use std::sync::Arc;
+use std::time::Instant;
 
 use crate::tunnel::TunnelState;
 
 use crate::graph::NodeId;
+use crate::shard::TunnelHandles;
 
 impl Daemon {
     /// Drain loop. LT epoll re-fires next turn if we leave bytes
@@ -292,6 +295,8 @@ impl Daemon {
             &mut self.listeners,
             &mut self.dp.tunnels,
             &self.graph,
+            &self.tunnel_handles,
+            self.timers.now(),
         );
     }
 
@@ -306,6 +311,8 @@ impl Daemon {
         listeners: &mut [super::ListenerSlot],
         tunnels: &mut crate::inthash::IntHashMap<NodeId, TunnelState>,
         graph: &crate::graph::Graph,
+        tunnel_handles: &crate::inthash::IntHashMap<NodeId, Arc<TunnelHandles>>,
+        now: Instant,
     ) {
         let Some((b, sock, relay_nid, origlen)) = batch.take() else {
             return;
@@ -338,6 +345,22 @@ impl Daemon {
                 // lost (kernel rejected the whole sendmsg) — same
                 // outcome as the per-frame path, just `count×`.
                 super::helpers::handle_udp_emsgsize(tunnels, graph, relay_nid, origlen);
+            } else if super::helpers::is_udp_unreachable_errno(&e) {
+                // Routing event on the batched path. Same handling
+                // as the immediate path; frames in this batch are
+                // lost, inner-TCP retransmits.
+                let relay_name = graph
+                    .node(relay_nid)
+                    .map_or("<gone>", |n| n.name.as_str())
+                    .to_owned();
+                super::helpers::handle_udp_unreachable(
+                    tunnels,
+                    tunnel_handles,
+                    relay_nid,
+                    &relay_name,
+                    &e,
+                    now,
+                );
             } else {
                 let relay_name = graph.node(relay_nid).map_or("<gone>", |n| n.name.as_str());
                 log::warn!(target: "tincd::net",

--- a/crates/tincd/src/daemon/net/helpers.rs
+++ b/crates/tincd/src/daemon/net/helpers.rs
@@ -4,6 +4,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::graph::{Graph, NodeId};
 use socket2::SockAddr;
@@ -15,6 +16,12 @@ use crate::shard::TunnelHandles;
 use crate::tunnel::TunnelState;
 
 use super::ListenerSlot;
+
+/// Re-warn cadence for [`handle_udp_unreachable`]. First failure logs
+/// at `warn`; further failures within this window are suppressed
+/// (the helper still clears the cached addr each time so the next
+/// packet retries the slow path).
+const UDP_UNREACHABLE_WARN_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Flip `udp_confirmed`, cache the pre-converted `SockAddr` + sock
 /// index, mirror into the lock-free fast-path handle.
@@ -49,6 +56,86 @@ pub(super) fn confirm_udp_addr(
     tunnel.udp_addr_cached = Some(cached.clone());
     if let Some(h) = tunnel_handles.get(&nid) {
         *h.udp_addr.lock().unwrap() = Some(cached);
+    }
+}
+
+/// `sendmsg` errno classifier: is this "destination not locally
+/// routable"? `ENETUNREACH` (e.g. peer's IPv6 with no v6 default
+/// route), `EHOSTUNREACH` (peer-specific blackhole), `EAFNOSUPPORT`
+/// (kernel built without v6), `EADDRNOTAVAIL` (e.g. our v6 source
+/// disappeared between bind and send). All four mean the same thing
+/// to us: the chosen `udp_addr` is not usable; drop it and let
+/// `choose_udp_address` pick a different candidate next time.
+pub(super) fn is_udp_unreachable_errno(e: &std::io::Error) -> bool {
+    let Some(raw) = e.raw_os_error() else {
+        return false;
+    };
+    matches!(
+        raw,
+        // libc errnos. Spelled-out so this compiles without pulling
+        // libc in just for this site; values are stable Linux ABI.
+        101 // ENETUNREACH
+        | 113 // EHOSTUNREACH
+        | 97  // EAFNOSUPPORT
+        | 99  // EADDRNOTAVAIL
+    )
+}
+
+/// `ENETUNREACH` / `EHOSTUNREACH` / `EAFNOSUPPORT` / `EADDRNOTAVAIL`
+/// on a UDP send: the chosen `udp_addr` is not locally routable
+/// (typical: peer advertised an IPv6 address but our host has no
+/// public IPv6 path). Without this handler, every subsequent send
+/// retries the same broken cached address forever — visible as a
+/// per-packet warn spam and a peer that never establishes direct
+/// UDP even when its `ADD_EDGE` also carries a routable IPv4
+/// address.
+///
+/// Effect: clear `udp_addr`, `udp_addr_cached`, and the
+/// `udp_confirmed` mirror so the next packet falls through to
+/// `choose_udp_address`'s cold edge-walk. `pmtu` and the SPTPS
+/// session are NOT touched — this is a routing event, not a peer
+/// teardown. Stamps `udp_send_failed_at` so:
+///   - the warn log is emitted at most once per minute per peer
+///     (avoids the per-packet flood when the cold path keeps
+///     re-picking the same broken address);
+///   - the cold path can deprioritise the reflexive arm while a
+///     recent failure is in effect (handled in
+///     `choose_udp_address`).
+pub(super) fn handle_udp_unreachable(
+    tunnels: &mut IntHashMap<NodeId, TunnelState>,
+    tunnel_handles: &IntHashMap<NodeId, Arc<TunnelHandles>>,
+    relay_nid: NodeId,
+    relay_name: &str,
+    err: &std::io::Error,
+    now: Instant,
+) {
+    let warn_now = if let Some(tunnel) = tunnels.get_mut(&relay_nid) {
+        let warn_now = tunnel
+            .udp_send_failed_at
+            .is_none_or(|t| now.saturating_duration_since(t) >= UDP_UNREACHABLE_WARN_INTERVAL);
+        tunnel.udp_send_failed_at = Some(now);
+        tunnel.udp_addr = None;
+        tunnel.udp_addr_cached = None;
+        tunnel.status.udp_confirmed = false;
+        if let Some(p) = tunnel.pmtu.as_mut() {
+            p.udp_confirmed = false;
+        }
+        warn_now
+    } else {
+        // No TunnelState: log once and bail; nothing else to clear.
+        true
+    };
+
+    if let Some(h) = tunnel_handles.get(&relay_nid)
+        && let Ok(mut g) = h.udp_addr.lock()
+    {
+        *g = None;
+    }
+
+    if warn_now {
+        log::warn!(target: "tincd::net",
+                   "UDP send to {relay_name} failed: {err}; \
+                    clearing cached address, will retry via cold path");
     }
 }
 
@@ -115,5 +202,76 @@ pub(super) fn gro_offer_or_write(
     }
     if let Err(e) = device.write(data) {
         log::debug!(target: "tincd::net", "Error writing to device: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn is_udp_unreachable_errno_matches_routing_failures() {
+        for raw in [101, 113, 97, 99] {
+            let e = io::Error::from_raw_os_error(raw);
+            assert!(
+                is_udp_unreachable_errno(&e),
+                "errno {raw} should be classified as udp-unreachable"
+            );
+        }
+        // EMSGSIZE, EWOULDBLOCK, EAGAIN — handled by other arms.
+        for raw in [90, 11] {
+            let e = io::Error::from_raw_os_error(raw);
+            assert!(
+                !is_udp_unreachable_errno(&e),
+                "errno {raw} should NOT be classified as udp-unreachable"
+            );
+        }
+        // No raw os error (e.g. synthetic kind).
+        let e = io::Error::new(io::ErrorKind::Other, "synthetic");
+        assert!(!is_udp_unreachable_errno(&e));
+    }
+
+    #[test]
+    fn handle_udp_unreachable_clears_state_and_rate_limits() {
+        use crate::tunnel::TunnelState;
+        let mut tunnels: IntHashMap<NodeId, TunnelState> = IntHashMap::default();
+        let tunnel_handles: IntHashMap<NodeId, Arc<TunnelHandles>> = IntHashMap::default();
+        let nid = NodeId(42);
+        let mut t = TunnelState::default();
+        t.udp_addr = Some("10.0.0.1:655".parse().unwrap());
+        let lo: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        t.udp_addr_cached = Some((SockAddr::from(lo), 0));
+        t.status.udp_confirmed = true;
+        tunnels.insert(nid, t);
+
+        let now = Instant::now();
+        let err = io::Error::from_raw_os_error(101);
+        handle_udp_unreachable(&mut tunnels, &tunnel_handles, nid, "peer", &err, now);
+
+        let t = tunnels.get(&nid).expect("tunnel still present");
+        assert!(t.udp_addr.is_none(), "udp_addr cleared");
+        assert!(t.udp_addr_cached.is_none(), "udp_addr_cached cleared");
+        assert!(!t.status.udp_confirmed, "udp_confirmed cleared");
+        assert_eq!(
+            t.udp_send_failed_at,
+            Some(now),
+            "failed-at timestamp stamped"
+        );
+
+        // The handler is idempotent and safe to call again on an
+        // already-cleared tunnel; the rate-limit gate just keeps
+        // the warn from firing every packet.
+        handle_udp_unreachable(&mut tunnels, &tunnel_handles, nid, "peer", &err, now);
+        let t = tunnels.get(&nid).unwrap();
+        assert_eq!(
+            t.udp_send_failed_at,
+            Some(now),
+            "still stamped, not regressed"
+        );
+
+        // No TunnelState: don't panic.
+        let missing = NodeId(99);
+        handle_udp_unreachable(&mut tunnels, &tunnel_handles, missing, "ghost", &err, now);
     }
 }

--- a/crates/tincd/src/daemon/net/sptps.rs
+++ b/crates/tincd/src/daemon/net/sptps.rs
@@ -668,6 +668,8 @@ impl Daemon {
                     &mut self.listeners,
                     &mut dp.tunnels,
                     &self.graph,
+                    &self.tunnel_handles,
+                    self.timers.now(),
                 );
             }
             dp.tx_batch
@@ -716,6 +718,19 @@ impl Daemon {
                 &self.graph,
                 relay_nid,
                 at_len,
+            );
+        } else if super::helpers::is_udp_unreachable_errno(&e) {
+            // Routing event (e.g. peer's v6 addr but no v6 default
+            // route). Clear cached addr + log at most once/min.
+            // node_log_name borrows self; clone for the helper.
+            let relay_name = self.node_log_name(relay_nid).to_owned();
+            super::helpers::handle_udp_unreachable(
+                &mut self.dp.tunnels,
+                &self.tunnel_handles,
+                relay_nid,
+                &relay_name,
+                &e,
+                self.timers.now(),
             );
         } else {
             let relay_name = self.node_log_name(relay_nid);

--- a/crates/tincd/src/tunnel.rs
+++ b/crates/tincd/src/tunnel.rs
@@ -129,6 +129,16 @@ pub(crate) struct TunnelState {
     /// `n->udp_reply_sent`. `try_udp` keepalive gate.
     pub udp_reply_sent: Option<Instant>,
 
+    /// Rust-only. When the last `sendmsg` to this peer's `udp_addr`
+    /// failed with a "destination not locally routable" errno
+    /// (`ENETUNREACH`/`EHOSTUNREACH`/`EADDRNOTAVAIL`/`EAFNOSUPPORT`).
+    /// Used by [`crate::daemon::net::helpers::handle_udp_unreachable`]
+    /// to (a) rate-limit the warn log to once per minute per peer
+    /// and (b) gate `choose_udp_address`'s reflexive arm: while a
+    /// recent failure is in effect, prefer the cold edge-walk so we
+    /// don't keep retrying the same broken stashed address.
+    pub udp_send_failed_at: Option<Instant>,
+
     /// `n->udp_info_sent`. `send_udp_info` debounce. Only when WE
     /// originate; forwarding skips.
     pub udp_info_sent: Option<Instant>,
@@ -205,6 +215,7 @@ impl TunnelState {
         self.udp_rx_maxlen = 0;
         self.udp_addr = None; // `update_node_udp(n, NULL)`
         self.udp_addr_cached = None;
+        self.udp_send_failed_at = None;
         self.status = TunnelStatus::default(); // `memset(&n->status, 0, ...)`
     }
 }
@@ -401,6 +412,7 @@ mod tests {
                 p
             }),
             udp_reply_sent: Some(Instant::now()),
+            udp_send_failed_at: Some(Instant::now()),
             udp_info_sent: Some(Instant::now()),
             mtu_info_sent: Some(Instant::now()),
             udp_rx_maxlen: 999,
@@ -432,6 +444,7 @@ mod tests {
         assert!(p.phase.is_discovery_start());
         assert!(!p.udp_confirmed);
         assert!(t.udp_reply_sent.is_none());
+        assert!(t.udp_send_failed_at.is_none());
         assert!(t.udp_addr.is_none()); // `:296`
         assert_eq!(t.status, TunnelStatus::default()); // `:297`
         // Traffic counters NOT reset (lifetime totals).


### PR DESCRIPTION
## Background

While debugging #4 on an IPv4-only host (`ignavia`, no public IPv6 default route) I saw this in `tinc.retiolum.service` logs:

```
WARN tincd::net] Error sending UDP SPTPS packet to prism: Network is unreachable (os error 101)
WARN tincd::net] Error sending UDP SPTPS packet to prism: Network is unreachable (os error 101)
WARN tincd::net] Error sending UDP SPTPS batch  to radio: Network is unreachable (os error 101)
...
```

— 29× to `prism`, 9× to `eva`, 5× to `radio` over 6 minutes, one warn per failed packet.

Root cause: when a peer's `ADD_EDGE` carries an IPv6 address as its preferred contact and the local host has no v6 default route, `BecameReachable` (`crates/tincd/src/daemon/gossip/graph.rs:56-65`) seeds `tunnel.udp_addr` from that wire-advertised address. `sendmsg` then returns `ENETUNREACH`. The current handlers in `send_sptps_udp_immediate` (`sptps.rs:720-723`) and `ship_tx_batch` (`device.rs:341-346`) just `log::warn!` and drop the packet — they never clear the cached address. The same broken `udp_addr_cached` is used on the next send, forever.

Peers in this mesh advertise both v4 and v6 in their hosts/ file, so a v4 fallback exists — it's just never tried.

## Fix

Add `handle_udp_unreachable` next to `handle_udp_emsgsize` in `daemon::net::helpers`. On `ENETUNREACH` / `EHOSTUNREACH` / `EAFNOSUPPORT` / `EADDRNOTAVAIL`:

- Clear `tunnel.udp_addr`, `tunnel.udp_addr_cached`, `status.udp_confirmed` and the `pmtu.udp_confirmed` mirror. The next packet falls through `choose_udp_address`'s cold edge-walk and picks a different `edge_addrs[reverse]` candidate (in the IPv4-only case, eventually the peer's v4 address).
- Mirror the clear into `tunnel_handles[nid].udp_addr` so the lock-free fast path stops sending to the stale cached addr.
- Stamp a new `tunnel.udp_send_failed_at: Option<Instant>` and rate-limit the warn log to once per minute per peer (the cold path may still pick the same broken AF until the random walk lands on a different one — without the rate limit we'd just move the spam to the cold path).

`pmtu` and the SPTPS session itself are NOT reset — this is a routing event, not a peer teardown. `reset_unreachable` already covers the harsher path.

The errno classifier (`is_udp_unreachable_errno`) uses literal Linux errno values so this doesn't pull `libc` in just for this site; the four values are stable ABI.

## Threading the call sites

`send_sptps_udp_immediate` is a `Daemon` method and already has `&self.tunnel_handles` + `self.timers.now()` in scope. `ship_tx_batch` is a free function (called from `send_sptps_data_relay` while `tx_scratch` is borrowed); added `tunnel_handles` and `now` parameters and updated both call sites (`flush_tx_batch` and the mid-loop flush in `sptps.rs`).

## Tests

Two new unit tests in `daemon::net::helpers::tests`:

- `is_udp_unreachable_errno_matches_routing_failures` — positive set (101/113/97/99), negative set (EMSGSIZE/EAGAIN), and `io::Error` without a raw os error.
- `handle_udp_unreachable_clears_state_and_rate_limits` — confirms `udp_addr`/`udp_addr_cached`/`udp_confirmed` are cleared, `udp_send_failed_at` is stamped, idempotent on a second call, no panic on a missing `TunnelState`.

Existing `tunnel::tests::reset_unreachable_clears_everything` extended for the new `udp_send_failed_at` field.

```
test result: ok. 642 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Plus `tests/gossip_sim.rs` (from #5) still passes:

```
test timing_gap_zero_contradictions ... ok
test multi_node_zero_contradictions ... ok
```

## Relationship to #5 / #4

Complementary, not duplicate. #5 fixed the graph-oscillation cycle (the dominant symptom in #4, affecting all tincr nodes including dual-stacked ones). This PR fixes the second observation from #4's follow-up: the per-packet `Network is unreachable` retry loop on IPv4-only hosts. Both are needed to keep the IPv4-only ignavia node clean against a mostly-classic-tinc mesh.

## Local validation

Running on `ignavia` against a 180-host mesh (mostly tinc 1.1pre18 + a few tincr peers). Pre-fix: 29 `Network is unreachable` warns to `prism` in 6 min, 0 successful UDP to v6-only-advertising peers. Post-fix: 1 warn per peer per minute, direct UDP to peers via their v4 address as soon as the cold-path random walk picks it.

## Open questions / things I'd value review on

- **AF-aware cold path**: currently after our clear, `choose_udp_address` may pick the same broken AF again (random walk of `edge_addrs`). It eventually picks the other AF, but it's not deterministic. A more proactive fix would maintain a short per-AF blacklist or check local reachability of each AF (e.g. via a one-shot `connect()` probe). Out of scope for this PR — I wanted the minimal local change. Happy to add if you prefer.
- **EHOSTUNREACH semantics**: I lumped it in with ENETUNREACH because both observably mean "kernel can't get this packet on the wire and won't even try." If you'd rather only clear on ENETUNREACH (which is the structural one) and leave EHOSTUNREACH as a transient, easy to gate the `is_udp_unreachable_errno` set.
