### PR TITLE
net: trim verbose comments in UDP unreachable handler

### DIFF
--- a/crates/tincd/src/daemon/net/device.rs
+++ b/crates/tincd/src/daemon/net/device.rs
@@ -346,9 +346,7 @@ impl Daemon {
                 // outcome as the per-frame path, just `count×`.
                 super::helpers::handle_udp_emsgsize(tunnels, graph, relay_nid, origlen);
             } else if super::helpers::is_udp_unreachable_errno(&e) {
-                // Routing event on the batched path. Same handling
-                // as the immediate path; frames in this batch are
-                // lost, inner-TCP retransmits.
+
                 let relay_name = graph
                     .node(relay_nid)
                     .map_or("<gone>", |n| n.name.as_str())

--- a/crates/tincd/src/daemon/net/helpers.rs
+++ b/crates/tincd/src/daemon/net/helpers.rs
@@ -1,6 +1,4 @@
-//! Small cross-path helpers for the net layer. All three bodies
-//! used to be duplicated at 2–3 call sites each; keep the logic
-//! here so drift can't reintroduce the bugs the audits caught.
+//! Shared helpers for the net layer.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -17,21 +15,14 @@ use crate::tunnel::TunnelState;
 
 use super::ListenerSlot;
 
-/// Re-warn cadence for [`handle_udp_unreachable`]. First failure logs
-/// at `warn`; further failures within this window are suppressed
-/// (the helper still clears the cached addr each time so the next
-/// packet retries the slow path).
+/// Re-warn cadence for [`handle_udp_unreachable`].
 const UDP_UNREACHABLE_WARN_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Flip `udp_confirmed`, cache the pre-converted `SockAddr` + sock
-/// index, mirror into the lock-free fast-path handle.
+/// Confirm a peer's UDP address: flip `udp_confirmed`, cache the
+/// `SockAddr` + sock index, mirror into the lock-free fast-path handle.
 ///
-/// Gate is `cached.is_none() OR addr changed`, not just addr-change:
-/// `gossip::BecameReachable` / `tx_control::UDP_INFO` seed `udp_addr`
-/// from `edge_addr` while clearing `udp_addr_cached`. If the peer then
-/// sends from that same addr the old `udp_addr != peer_addr` gate
-/// would stay false forever and every send fell through to
-/// `choose_udp_address` (the 2.18% self-time cold path).
+/// Gates on `cached.is_none() OR addr changed` — not just addr-change —
+/// because gossip seeds `udp_addr` while clearing `udp_addr_cached`.
 pub(super) fn confirm_udp_addr(
     tunnels: &mut IntHashMap<NodeId, TunnelState>,
     listeners: &[ListenerSlot],
@@ -59,21 +50,16 @@ pub(super) fn confirm_udp_addr(
     }
 }
 
-/// `sendmsg` errno classifier: is this "destination not locally
-/// routable"? `ENETUNREACH` (e.g. peer's IPv6 with no v6 default
-/// route), `EHOSTUNREACH` (peer-specific blackhole), `EAFNOSUPPORT`
-/// (kernel built without v6), `EADDRNOTAVAIL` (e.g. our v6 source
-/// disappeared between bind and send). All four mean the same thing
-/// to us: the chosen `udp_addr` is not usable; drop it and let
-/// `choose_udp_address` pick a different candidate next time.
+/// Returns `true` for `sendmsg` errnos meaning "destination not
+/// locally routable" (`ENETUNREACH`, `EHOSTUNREACH`, `EAFNOSUPPORT`,
+/// `EADDRNOTAVAIL`).
 pub(super) fn is_udp_unreachable_errno(e: &std::io::Error) -> bool {
     let Some(raw) = e.raw_os_error() else {
         return false;
     };
     matches!(
         raw,
-        // libc errnos. Spelled-out so this compiles without pulling
-        // libc in just for this site; values are stable Linux ABI.
+        // Stable Linux ABI values.
         101 // ENETUNREACH
         | 113 // EHOSTUNREACH
         | 97  // EAFNOSUPPORT
@@ -81,26 +67,10 @@ pub(super) fn is_udp_unreachable_errno(e: &std::io::Error) -> bool {
     )
 }
 
-/// `ENETUNREACH` / `EHOSTUNREACH` / `EAFNOSUPPORT` / `EADDRNOTAVAIL`
-/// on a UDP send: the chosen `udp_addr` is not locally routable
-/// (typical: peer advertised an IPv6 address but our host has no
-/// public IPv6 path). Without this handler, every subsequent send
-/// retries the same broken cached address forever — visible as a
-/// per-packet warn spam and a peer that never establishes direct
-/// UDP even when its `ADD_EDGE` also carries a routable IPv4
-/// address.
-///
-/// Effect: clear `udp_addr`, `udp_addr_cached`, and the
-/// `udp_confirmed` mirror so the next packet falls through to
-/// `choose_udp_address`'s cold edge-walk. `pmtu` and the SPTPS
-/// session are NOT touched — this is a routing event, not a peer
-/// teardown. Stamps `udp_send_failed_at` so:
-///   - the warn log is emitted at most once per minute per peer
-///     (avoids the per-packet flood when the cold path keeps
-///     re-picking the same broken address);
-///   - the cold path can deprioritise the reflexive arm while a
-///     recent failure is in effect (handled in
-///     `choose_udp_address`).
+/// Handle "destination unreachable" on UDP send: clear cached
+/// `udp_addr` so `choose_udp_address` picks a different candidate.
+/// Rate-limits the warn log to once per [`UDP_UNREACHABLE_WARN_INTERVAL`]
+/// per peer. Does NOT tear down SPTPS or pmtu — this is a routing event.
 pub(super) fn handle_udp_unreachable(
     tunnels: &mut IntHashMap<NodeId, TunnelState>,
     tunnel_handles: &IntHashMap<NodeId, Arc<TunnelHandles>>,
@@ -122,7 +92,6 @@ pub(super) fn handle_udp_unreachable(
         }
         warn_now
     } else {
-        // No TunnelState: log once and bail; nothing else to clear.
         true
     };
 
@@ -139,10 +108,8 @@ pub(super) fn handle_udp_unreachable(
     }
 }
 
-/// `EMSGSIZE` on a UDP send: LOCAL kernel rejected at interface MTU.
-/// Shrink the relay's `maxmtu` so the NEXT batch's stride fits. The
-/// frames in THIS send are lost — inner-TCP retransmits. This IS the
-/// discovery mechanism; don't warn.
+/// `EMSGSIZE` on UDP send: shrink relay's `maxmtu` so the next
+/// batch fits. Current frames are lost; inner-TCP retransmits.
 pub(super) fn handle_udp_emsgsize(
     tunnels: &mut IntHashMap<NodeId, TunnelState>,
     graph: &Graph,
@@ -158,18 +125,14 @@ pub(super) fn handle_udp_emsgsize(
     }
 }
 
-/// Offer `data` (raw IP — caller strips the synth eth header) to
-/// the GRO bucket, flushing as needed; writes through to the device
-/// on `NotCandidate` / flushed-and-didn't-fit. Shared between
-/// `send_packet_myself` and `rx_fast_sink`.
+/// Offer raw IP `data` to GRO bucket, flushing as needed; falls
+/// through to direct device write on `NotCandidate`.
 pub(super) fn gro_offer_or_write(
     device: &mut Box<dyn Device>,
     gro: &mut Option<GroBucket>,
     data: &mut [u8],
 ) {
     const ETH_HLEN: usize = 14;
-    // `gro_enabled` setup gate makes the write_super Unsupported
-    // path unreachable in practice; warn (not debug) if we hit it.
     let flush = |device: &mut Box<dyn Device>, b: &mut GroBucket| {
         if let Some(buf) = b.flush()
             && let Err(e) = device.write_super(buf)
@@ -193,9 +156,7 @@ pub(super) fn gro_offer_or_write(
                 }
             }
             GroVerdict::NotCandidate => {
-                // Ordering: anything in the bucket goes out first.
-                // A same-flow non-candidate (FIN) mustn't reorder
-                // past lower-seq data.
+                // Flush first to preserve ordering.
                 flush(device, bucket);
             }
         }
@@ -219,7 +180,6 @@ mod tests {
                 "errno {raw} should be classified as udp-unreachable"
             );
         }
-        // EMSGSIZE, EWOULDBLOCK, EAGAIN — handled by other arms.
         for raw in [90, 11] {
             let e = io::Error::from_raw_os_error(raw);
             assert!(
@@ -227,7 +187,6 @@ mod tests {
                 "errno {raw} should NOT be classified as udp-unreachable"
             );
         }
-        // No raw os error (e.g. synthetic kind).
         let e = io::Error::new(io::ErrorKind::Other, "synthetic");
         assert!(!is_udp_unreachable_errno(&e));
     }
@@ -259,9 +218,7 @@ mod tests {
             "failed-at timestamp stamped"
         );
 
-        // The handler is idempotent and safe to call again on an
-        // already-cleared tunnel; the rate-limit gate just keeps
-        // the warn from firing every packet.
+        // Idempotent: second call on same timestamp suppresses warn.
         handle_udp_unreachable(&mut tunnels, &tunnel_handles, nid, "peer", &err, now);
         let t = tunnels.get(&nid).unwrap();
         assert_eq!(
@@ -270,7 +227,6 @@ mod tests {
             "still stamped, not regressed"
         );
 
-        // No TunnelState: don't panic.
         let missing = NodeId(99);
         handle_udp_unreachable(&mut tunnels, &tunnel_handles, missing, "ghost", &err, now);
     }

--- a/crates/tincd/src/daemon/net/sptps.rs
+++ b/crates/tincd/src/daemon/net/sptps.rs
@@ -720,8 +720,6 @@ impl Daemon {
                 at_len,
             );
         } else if super::helpers::is_udp_unreachable_errno(&e) {
-            // Routing event (e.g. peer's v6 addr but no v6 default
-            // route). Clear cached addr + log at most once/min.
             // node_log_name borrows self; clone for the helper.
             let relay_name = self.node_log_name(relay_nid).to_owned();
             super::helpers::handle_udp_unreachable(

--- a/crates/tincd/src/tunnel.rs
+++ b/crates/tincd/src/tunnel.rs
@@ -129,14 +129,9 @@ pub(crate) struct TunnelState {
     /// `n->udp_reply_sent`. `try_udp` keepalive gate.
     pub udp_reply_sent: Option<Instant>,
 
-    /// Rust-only. When the last `sendmsg` to this peer's `udp_addr`
-    /// failed with a "destination not locally routable" errno
-    /// (`ENETUNREACH`/`EHOSTUNREACH`/`EADDRNOTAVAIL`/`EAFNOSUPPORT`).
-    /// Used by [`crate::daemon::net::helpers::handle_udp_unreachable`]
-    /// to (a) rate-limit the warn log to once per minute per peer
-    /// and (b) gate `choose_udp_address`'s reflexive arm: while a
-    /// recent failure is in effect, prefer the cold edge-walk so we
-    /// don't keep retrying the same broken stashed address.
+    /// Last "destination unreachable" timestamp for this peer's UDP
+    /// path. Used to rate-limit warnings and deprioritise the
+    /// reflexive arm in `choose_udp_address`.
     pub udp_send_failed_at: Option<Instant>,
 
     /// `n->udp_info_sent`. `send_udp_info` debounce. Only when WE


### PR DESCRIPTION
Shorten doc comments and inline comments from #6 — keep WHY, drop WHAT paraphrasing. ~50 lines removed across 4 files.