### PR TITLE
gossip: stop broadcasting reverse-edge DEL_EDGE in on_del_edge (#8)

### DIFF
--- a/crates/tincd/src/daemon/gossip/edges.rs
+++ b/crates/tincd/src/daemon/gossip/edges.rs
@@ -6,7 +6,6 @@ use crate::daemon::{ConnId, Daemon};
 use crate::dispatch::{DispatchError, parse_add_edge, parse_del_edge};
 
 use tinc_proto::AddrStr;
-use tinc_proto::msg::DelEdge;
 
 impl Daemon {
     /// Edge exists with different params ⇒ update in place (`Graph::`
@@ -180,7 +179,7 @@ impl Daemon {
             return Ok(nw);
         }
 
-        let mut nw = if self.settings.tunnelserver {
+        let nw = if self.settings.tunnelserver {
             false
         } else {
             self.forward_request(from_conn, body)
@@ -191,26 +190,15 @@ impl Daemon {
 
         self.run_graph_and_log();
 
-        // If `to` became unreachable AND has edge back to us (the
-        // synthesized reverse from on_ack), delete + broadcast.
+        // If `to` became unreachable and we still hold a synthesized
+        // reverse edge `to → myself` (from on_ack), drop it locally
+        // but do NOT broadcast DEL_EDGE for it. That edge is owned by
+        // `to`; broadcasting our local SSSP observation on its behalf
+        // makes every receiver do the same, cascading (issue #8). If
+        // `to` is really dead, its meta-peers send first-party DELs.
         if !self.graph.node(to_id).is_some_and(|n| n.reachable)
             && let Some(rev) = self.graph.lookup_edge(to_id, self.myself)
         {
-            if !self.settings.tunnelserver {
-                let line = DelEdge {
-                    from: edge.to,
-                    to: self.name.clone(),
-                }
-                .format(Self::nonce());
-                // `97ef5af0` bug class: this DEL_EDGE was queued but
-                // never armed WRITE. `purge()` below CAN cover it (same
-                // conns, broadcast = all active) - but only if purge has
-                // anything to broadcast. After `del_edge(rev)` below,
-                // `to` has zero outgoing edges; if it also owns no
-                // subnets, purge pass-1 emits nothing, `nw_purge=false`,
-                // and this line sits for up to pinginterval. OR it in.
-                nw |= self.broadcast_line(&line);
-            }
             self.graph.del_edge(rev);
             self.edge_addrs.remove(&rev);
         }

--- a/crates/tincd/tests/gossip_sim.rs
+++ b/crates/tincd/tests/gossip_sim.rs
@@ -107,6 +107,12 @@ struct Simulation {
     hop_delay: u64,
     nonce_counter: u64,
     msg_count: u64,
+    /// Models the pre-fix `on_del_edge` reverse-broadcast (issue #8):
+    /// when a DEL_EDGE makes `b` unreachable and a synthesized
+    /// reverse `b → self` exists, broadcast `DEL_EDGE(b, self)`.
+    reverse_broadcast_amplifier: bool,
+    /// DEL_EDGE envelopes enqueued (originals + forwards + amplifier).
+    del_edge_enqueued: u64,
 }
 
 impl Simulation {
@@ -118,6 +124,8 @@ impl Simulation {
             hop_delay,
             nonce_counter: 0,
             msg_count: 0,
+            reverse_broadcast_amplifier: false,
+            del_edge_enqueued: 0,
         }
     }
 
@@ -186,6 +194,9 @@ impl Simulation {
     }
 
     fn send_msg(&mut self, sender: &str, dest: &str, msg: Msg, nonce: u64) {
+        if matches!(msg, Msg::DelEdge { .. }) {
+            self.del_edge_enqueued += 1;
+        }
         self.queue.push_back(Envelope {
             arrive_tick: self.tick + self.hop_delay,
             sender: sender.to_string(),
@@ -226,6 +237,7 @@ impl Simulation {
                         msg: msg.clone(),
                         nonce,
                     });
+                    self.del_edge_enqueued += 1;
                 }
             }
         }
@@ -360,6 +372,29 @@ impl Simulation {
                     // doing so caused a contradiction storm that
                     // made the mesh oscillate. Purge is only
                     // triggered by explicit `tinc purge` (REQ_PURGE).
+
+                    // Reverse-broadcast amplifier (issue #8); see
+                    // field doc. Conditional so tests can compare
+                    // cascade size with amplifier on vs off.
+                    if self.reverse_broadcast_amplifier
+                        && !peer.graph.node(to_id).is_some_and(|n| n.reachable)
+                        && peer.graph.lookup_edge(to_id, peer.myself).is_some()
+                    {
+                        let amp_msg = Msg::DelEdge {
+                            from: to.clone(),
+                            to: dest_name.clone(),
+                        };
+                        let amp_peers: Vec<String> = peer.meta_peers.clone();
+                        let amp_nonce = alloc_nonce();
+                        for p in &amp_peers {
+                            outgoing.push((
+                                dest_name.clone(),
+                                p.clone(),
+                                amp_msg.clone(),
+                                amp_nonce,
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -482,4 +517,73 @@ fn multi_node_zero_contradictions() {
             "{obs}: carol should be reachable"
         );
     }
+}
+
+/// Regression for issue #8: receiver R holds a synthesized reverse
+/// `V → R` but no forward `R → V`, then receives `DEL_EDGE(W, V)`
+/// deleting V's last visible edge. Pre-fix, R would broadcast a
+/// fresh `DEL_EDGE(V, R)` to each meta-peer; post-fix it only
+/// forwards the inbound message.
+#[test]
+fn reverse_broadcast_amplifier_emits_extra_del_edge() {
+    fn build_scenario(amplifier_on: bool) -> u64 {
+        let mut sim = Simulation::new(0);
+        sim.reverse_broadcast_amplifier = amplifier_on;
+
+        for name in ["R", "W", "V", "X", "Y"] {
+            sim.add_node(name);
+        }
+
+        // X/Y are passive forwarding targets only.
+        sim.nodes.get_mut("R").unwrap().meta_peers = vec!["X".into(), "Y".into()];
+
+        // Craft R's graph: only V→R and W→V. No R→V, so V is
+        // unreachable from R both before and after W→V is deleted.
+        {
+            let r = sim.nodes.get_mut("R").unwrap();
+            let w_id = r.lookup_or_add("W");
+            let v_id = r.lookup_or_add("V");
+            r.graph.add_edge(w_id, v_id, 0, 0);
+            r.graph.add_edge(v_id, r.myself, 0, 0);
+            r.run_sssp();
+            assert!(
+                !r.graph.node(v_id).unwrap().reachable,
+                "test setup: V should be unreachable from R (no R→V edge)"
+            );
+            assert!(
+                r.graph.lookup_edge(v_id, r.myself).is_some(),
+                "test setup: reverse V→R must be present"
+            );
+        }
+
+        // Sender isn't a forwarding target so emit counts are clean.
+        let nonce = sim.next_nonce();
+        let baseline = sim.del_edge_enqueued;
+        sim.send_msg(
+            "outside",
+            "R",
+            Msg::DelEdge {
+                from: "W".into(),
+                to: "V".into(),
+            },
+            nonce,
+        );
+        sim.run(3);
+        sim.del_edge_enqueued - baseline
+    }
+
+    let quiet_emits = build_scenario(false);
+    let loud_emits = build_scenario(true);
+
+    // OFF: 1 inbound + 2 forwards = 3. ON: + 2 reverse emits = 5.
+    assert_eq!(
+        quiet_emits, 3,
+        "post-fix should emit only the inbound DEL_EDGE + 2 forwards; \
+         got {quiet_emits}"
+    );
+    assert_eq!(
+        loud_emits, 5,
+        "amplifier ON should emit inbound + 2 forwards + 2 reverse \
+         broadcasts; got {loud_emits}"
+    );
 }


### PR DESCRIPTION
Fixes the remaining DEL_EDGE cascade amplifier described in #8. Draft until evo/eve logs are available to fully characterize cascade origin — the structural argument and tests stand independent of those.

## Background

PR #5 stopped the `purge()` form of the contradiction storm on `on_del_edge`. A smaller residual remained: the reverse-edge broadcast block at the end of `on_del_edge`, which broadcasts \`DEL_EDGE(to, self)\` for a synthesized reverse edge \`to → self\` whenever the just-deleted edge made \`to\` unreachable.

That reverse edge is **owned by \`to\`** (per tinc gossip semantics, each node broadcasts ADD_EDGE for its own outgoing edges). Broadcasting it on \`to\`'s behalf gossips our transient local SSSP observation as if it were authoritative. Every receiver running the same check fires its own reverse-broadcast — cascade.

## Empirical impact (issue #8)

On a 180-host mixed tincr / tinc-1.1pre18 mesh, one peer's PING-timeout triggered **241 forwarded DEL_EDGE messages in a 3-second window** on a single observer, marking ~60 nodes unreachable for ~3 minutes. Full log artifacts in the issue. Cross-referenced against three hosts (\`neoprism\`, \`hotdog\`, \`prism\`); evo and eve logs would help quantify first-party vs amplified origin but aren't required to validate the fix.

## Change

Remove the \`broadcast_line\` call in \`on_del_edge\`'s reverse-edge cleanup. Keep the local \`graph.del_edge(rev)\` + \`edge_addrs.remove(&rev)\` so our SSSP stays consistent — only the gossip is removed.

Mirrors PR #5's principle: only the edge owner broadcasts DEL_EDGE for that edge.

## Test

Extended \`gossip_sim.rs\` with a \`reverse_broadcast_amplifier\` knob that simulates the pre-fix code path. New test \`reverse_broadcast_amplifier_emits_extra_del_edge\` constructs the exact pre-condition the amplifier required (receiver R has synthesized reverse \`V → R\` but no forward \`R → V\`, plus an inbound \`DEL_EDGE(W, V)\` deleting V's last visible edge). Asserts:

- amplifier OFF (post-fix, default): 1 inbound + 2 forwards = 3 DEL_EDGEs total
- amplifier ON (pre-fix): 1 inbound + 2 forwards + 2 reverse-broadcasts = 5 DEL_EDGEs total

\`\`\`
test reverse_broadcast_amplifier_emits_extra_del_edge ... ok
test timing_gap_zero_contradictions ... ok
test multi_node_zero_contradictions ... ok
\`\`\`

Plus all 642 lib tests pass, plus existing bugs tests (3) pass.

## Open questions for review

1. Should the analogous block in \`connect.rs:378-400\` (reverse-broadcast when our own meta-conn drops and the peer becomes unreachable) also have its broadcast removed? Same structural argument applies; I left it alone for now because it fires O(meta-conn-drops) which is much smaller than \`on_del_edge\`'s O(received-DEL_EDGEs). Happy to extend if you agree.

2. The simulation models the amplifier explicitly so we can A/B compare. An alternative would be a full integration test with a real Daemon under \`tests/two_daemons/\` style — heavier, and there's no existing fixture for the precise condition (asymmetric edge state). The sim-based test seems the right precision/cost trade-off but I'd value your read.

3. In mixed meshes, classic tinc-1.1pre18 peers still contribute to the cascade (no PR #5 fix, no this fix). Q3 in issue #8 raises whether tincr should additionally dampen received DEL_EDGE storms (coalescing per \`to\`). Separate change.

## Acknowledged log gaps

The cascade analysis in #8 is based on logs from three nodes (\`neoprism\`, \`hotdog\`, \`prism\`) — all we have access to. \`evo\` (the trigger node, 93.104.23.127) and \`eve\` (an apparent secondary amplifier) are upstream-managed. Their logs would help quantify how much of the 241 cascade was first-party (legitimate connect.rs broadcasts) vs. amplified (this fix's target).