### PR TITLE
gossip: drop REQ_KEY/ANS_KEY relays whose nexthop is the source conn (#10)

### DIFF
--- a/crates/tincd/src/daemon/gossip/keys.rs
+++ b/crates/tincd/src/daemon/gossip/keys.rs
@@ -148,6 +148,7 @@ impl Daemon {
     /// addr for the punch hint (see body comment).
     fn relay_req_key(
         &mut self,
+        from_conn: ConnId,
         to_nid: NodeId,
         from_nid: NodeId,
         msg: &ReqKey,
@@ -247,6 +248,20 @@ impl Daemon {
                        msg.to);
             return Some(false);
         };
+        // Loop break: our nexthop toward `to` is the same meta-conn
+        // the message came in on. The upstream peer disagrees with our
+        // SSSP about the route to `to` (or vice versa). Without this
+        // guard the message ping-pongs at meta-conn wire speed until
+        // gossip reconverges, saturating both sides' write queues —
+        // see issue #N (REQ_KEY/ANS_KEY relay loop). C tinc has the
+        // equivalent check (`c == from->nexthop->connection`).
+        if conn_id == from_conn {
+            log::debug!(target: "tincd::proto",
+                        "Dropping REQ_KEY {} → {} relay: nexthop loops back \
+                         to source {}",
+                        msg.from, msg.to, conn_name);
+            return Some(false);
+        }
         let Some(conn) = self.conns.get_mut(conn_id) else {
             return Some(false);
         };
@@ -276,7 +291,9 @@ impl Daemon {
             return Ok(false);
         };
 
-        if let Some(nw) = self.relay_req_key(to_nid, from_nid, &msg, body_str, &conn_name) {
+        if let Some(nw) =
+            self.relay_req_key(from_conn, to_nid, from_nid, &msg, body_str, &conn_name)
+        {
             return Ok(nw);
         }
 
@@ -547,6 +564,14 @@ impl Daemon {
                            msg.to);
                 return Ok(false);
             };
+            // Loop break: see relay_req_key for the rationale.
+            if conn_id == from_conn {
+                log::debug!(target: "tincd::proto",
+                            "Dropping ANS_KEY {} → {} relay: nexthop loops back \
+                             to source {}",
+                            msg.from, msg.to, conn_name);
+                return Ok(false);
+            }
             let Some(conn) = self.conns.get_mut(conn_id) else {
                 return Ok(false);
             };


### PR DESCRIPTION
## Summary

Fixes #10. Adds a one-line loop-break to both routed key-relay sites: drop the relay when `conn_for_nexthop(to_nid)` equals the conn the message arrived on.

- `relay_req_key` (`crates/tincd/src/daemon/gossip/keys.rs:149`): now takes `from_conn` and compares before forwarding
- `on_ans_key` relay arm (`:497`): already has `from_conn` in scope, same check inline

Equivalent to C tinc's `c == from->nexthop->connection` in `protocol_key.c`, which the rewrite did not carry over.

## Why

See #10 for the production storm: 77 minutes, ~1.5M relay lines on a single observer, peaked at 41k/min and knocked 30+ unrelated peers offline via meta-conn write-queue saturation. The SPTPS handshake never completed because every REQ_KEY and ANS_KEY just ping-ponged between two nodes whose SSSPs disagreed on the nexthop to a third (flaky) node. Routed messages have no TTL and no `seen_request` dedup, so there is no other natural exit.

## Diff shape

```rust
let Some(conn_id) = self.conn_for_nexthop(to_nid) else { … };
if conn_id == from_conn {
    log::debug!(target: \"tincd::proto\",
                \"Dropping REQ_KEY {} → {} relay: nexthop loops back \
                 to source {}\",
                msg.from, msg.to, conn_name);
    return Some(false);
}
```

Same shape for `ANS_KEY`. `from_conn` was already in scope on both callers (`on_req_key:267`, `on_ans_key:499`); only `relay_req_key` needed a new arg.

## Why this is safe to drop unconditionally

The condition (\"the meta-conn I am about to forward this to is the meta-conn it just came from\") is never legitimate. The upstream peer chose us as its nexthop to `to`, and we are choosing the upstream peer as our nexthop to `to` — exactly one of the two views is stale, and forwarding either direction makes it worse, not better. Recovery happens via the normal `REQ_KEY_RETRY` 10s timer plus the gossip reconvergence that fixes the SSSP disagreement.

## Test plan

- [x] `cargo build -p tincd`
- [x] `cargo clippy -p tincd -- -D warnings`
- [x] `cargo test -p tincd --lib` (642 passed)
- [x] `cargo test -p tincd --test two_daemons reqkey_race` (relay handshake still completes)
- [x] `cargo test -p tincd --test two_daemons three_daemon` (3-node legitimate relay still works)

## Regression test

Open to suggestions on where this should live. The natural shape is a 3-node test where alice and bob each pick the other as nexthop to a third node `ghost`, then alice's REQ_KEY for ghost is observed to die at bob's relay site rather than bounce back. The gossip_sim simulator (`tests/gossip_sim.rs`) only models flooded messages today; extending it to also model routed-nexthop forwarding would cover this cleanly. Happy to draft that as a follow-up if it fits your preferred shape.