### PR TITLE
flake: add packages.default = tincd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,8 @@
     in
     {
       packages = eachSystem (
-        _: pkgs: {
+        system: pkgs: {
+          default = self.packages.${system}.tincd;
           kat-vectors = pkgs.callPackage ./nix/kat-vectors.nix { };
           kat-graph = pkgs.callPackage ./nix/kat-graph.nix { };
           kat-checksum = pkgs.callPackage ./nix/kat-checksum.nix { };


### PR DESCRIPTION
`nix shell github:Mic92/tincr` failed with "does not provide attribute 'packages.\*.default'". Point default at `tincd`, which already bundles `tinc`, `sptps_keypair`, `tinc-auth`, `tinc-dht-seed`.