### PR TITLE
nix: add tincd-compat output for pre-AVX2 x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ cargo install --git https://github.com/Mic92/tincr --locked tincd
 nix build github:Mic92/tincr#packages.x86_64-linux.tincd
 ```
 
+> **x86_64 CPU baseline:** the default `tincd` output targets
+> `x86-64-v3` (Haswell/2013+, AVX2). On older or low-power chips
+> (pre-Haswell, Atom, AMD Jaguar) it will `SIGILL`; use the
+> runtime-dispatched build instead:
+>
+> ```sh
+> nix build github:Mic92/tincr#packages.x86_64-linux.tincd-compat
+> ```
+
 ## Quick start
 
 See [docs/QUICKSTART.md](docs/QUICKSTART.md) for the two-node

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,8 @@
           tincd = pkgs.callPackage ./nix/tincd.nix {
             craneLib = crane.mkLib pkgs;
           };
+          # Pre-Haswell x86_64 (no AVX2). See baselineCpu in tincd.nix.
+          tincd-compat = self.packages.${system}.tincd.override { baselineCpu = true; };
         }
       );
 

--- a/nix/tincd.nix
+++ b/nix/tincd.nix
@@ -8,6 +8,9 @@
   craneLib,
   lib,
   installShellFiles,
+  # true → drop the x86-64-v3/AVX2 floor from .cargo/config.toml so
+  # the binary runs on pre-Haswell x86_64. Slower crypto, no SIGILL.
+  baselineCpu ? false,
 }:
 let
   rustSrc = lib.fileset.unions [
@@ -32,6 +35,12 @@ let
     # netns tests need bwrap+userns the sandbox lacks. The dev shell
     # runs the full suite; this is the deployment artifact.
     doCheck = false;
+  }
+  // lib.optionalAttrs baselineCpu {
+    # Env RUSTFLAGS replaces .cargo/config.toml's target.* rustflags
+    # (cargo does not merge them); restate frame-pointers, omit
+    # target-cpu=x86-64-v3 and chacha20_force_avx2.
+    RUSTFLAGS = "-C force-frame-pointers=yes";
   };
   # Dummy src/{lib,main}.rs from every workspace Cargo.toml; compiles
   # all crates.io deps. Rebuilds only when Cargo.{toml,lock} change.


### PR DESCRIPTION
.cargo/config.toml pins x86_64 builds to target-cpu=x86-64-v3 plus
--cfg chacha20_force_avx2 so the RustCrypto AVX2 backends inline.
That SIGILLs on pre-Haswell and Atom/Jaguar-class hardware.

Add a baselineCpu argument to nix/tincd.nix that sets RUSTFLAGS in
the environment. Cargo uses env RUSTFLAGS instead of the config-file
target.*.rustflags block (no merging), so restating only
force-frame-pointers drops the v3 target-cpu and the force_avx2 cfg;
chacha20/poly1305 fall back to runtime cpuid dispatch.

Expose as packages.*.tincd-compat and note the CPU floor in the
README install section.