### PR TITLE
nixos: always start tincr in multi-user.target

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -311,7 +311,9 @@ let
         "systemd-networkd.service"
       ];
       wants = [ "network-online.target" ];
-      wantedBy = mkIf (!net.socketActivation) [ "multi-user.target" ];
+      # tincd dials out itself, so it can't rely on socket activation to start.
+      wantedBy = [ "multi-user.target" ];
+      requires = mkIf net.socketActivation [ "${unitName netName}.socket" ];
 
       restartTriggers = [ (mkTincConf netName net) ];
 


### PR DESCRIPTION
tincd dials out itself, so socket activation alone leaves the VPN down after a rebuild until an incoming packet arrives.