### PR TITLE
tincd: enforce MINMTU as the UDP-usability gate (control + data plane)

### DIFF
--- a/crates/tincd/src/daemon/net/sptps.rs
+++ b/crates/tincd/src/daemon/net/sptps.rs
@@ -536,9 +536,15 @@ impl Daemon {
         let nexthop_nid = route.nexthop;
 
         // PROBE always prefers via (tiny + measures via's MTU); data
-        // prefers via only if it FITS. minmtu=0 until discovery →
-        // data goes hop-by-hop via nexthop until then (correct).
-        let via_minmtu = self.dp.tunnels.get(&via_nid).map_or(0, TunnelState::minmtu);
+        // prefers via only if it FITS a *usable* UDP MTU. `usable_minmtu`
+        // is 0 until discovery proves MINMTU (512), so a path that only
+        // passes keepalive-sized probes (symmetric NAT / flaky link)
+        // never attracts real data onto its blackholing direct hop.
+        let via_minmtu = self
+            .dp
+            .tunnels
+            .get(&via_nid)
+            .map_or(0, TunnelState::usable_minmtu);
         let relay_nid = if via_nid != self.myself
             && (record_type == PKT_PROBE || origlen <= usize::from(via_minmtu))
         {
@@ -562,15 +568,17 @@ impl Daemon {
         let tcponly =
             (self.myself_options.bits() | relay_options) & crate::dispatch::OPTION_TCPONLY != 0;
 
-        // C parity (`net_packet.c:974`): data stays on TCP until a
-        // probe reply lifts `minmtu` above 0. Probes are exempt so
-        // discovery still runs; behind a UDP-blackholing firewall
-        // minmtu stays 0 and data correctly never goes UDP.
+        // Data stays on TCP until discovery proves a *usable* UDP MTU
+        // (>= MINMTU). Probes are exempt so discovery still runs; behind
+        // a UDP-blackholing / sub-MINMTU path `usable_minmtu` stays 0 and
+        // data correctly never goes UDP (issue #21). Diverges from C
+        // net_packet.c:974 ("minmtu > 0"), which lets tiny-probe noise
+        // pin real data to a dead direct path.
         let relay_minmtu = self
             .dp
             .tunnels
             .get(&relay_nid)
-            .map_or(0, TunnelState::minmtu);
+            .map_or(0, TunnelState::usable_minmtu);
         let too_big = record_type != PKT_PROBE && origlen > usize::from(relay_minmtu);
         let go_tcp = record_type == tinc_sptps::REC_HANDSHAKE
             || tcponly

--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -160,7 +160,11 @@ impl Daemon {
         // reading the post-action value covers all three. None until
         // first HandshakeDone (probes start after the SPTPS dance).
         if let Some(h) = self.tunnel_handles.get(&peer) {
-            let m = self.dp.tunnels.get(&peer).map_or(0, TunnelState::minmtu);
+            let m = self
+                .dp
+                .tunnels
+                .get(&peer)
+                .map_or(0, TunnelState::usable_minmtu);
             h.minmtu.store(m, std::sync::atomic::Ordering::Relaxed);
         }
         // UDP-discovery timeout is checked inline in `try_udp`
@@ -1366,7 +1370,11 @@ impl Daemon {
         // Publish minmtu to the fast path (same as the real probe-
         // reply arm; seconds-apart, not hot).
         if let Some(h) = self.tunnel_handles.get(&peer) {
-            let m = self.dp.tunnels.get(&peer).map_or(0, TunnelState::minmtu);
+            let m = self
+                .dp
+                .tunnels
+                .get(&peer)
+                .map_or(0, TunnelState::usable_minmtu);
             h.minmtu.store(m, std::sync::atomic::Ordering::Relaxed);
         }
     }

--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -1126,6 +1126,14 @@ impl Daemon {
             via_nexthop_nid.and_then(|v| self.pmtu_snapshot(v)),
         );
 
+        // A converged direct/relay PMTU below `MTU_MIN` (512) means UDP to
+        // `from` is unusable; advertising it would trip the peer's fatal
+        // `mtu < 512` teardown and loop. Suppress — see `mtu_info_sendable`
+        // and issue #21.
+        if !udp_info::mtu_info_sendable(mtu) {
+            return false;
+        }
+
         if from_is_myself {
             self.dp.tunnels.entry(to_nid).or_default().mtu_info_sent = Some(now);
         }

--- a/crates/tincd/src/tunnel.rs
+++ b/crates/tincd/src/tunnel.rs
@@ -317,6 +317,21 @@ impl TunnelState {
         self.pmtu.as_ref().map_or(0, |p| p.minmtu)
     }
 
+    /// `minmtu`, but only once it has reached the UDP-usability floor
+    /// (`MINMTU` = 512, the IPv4 minimum reassembly size). Below that the
+    /// path has NOT been proven to carry a real datagram — a value like
+    /// 18 (`MIN_PROBE_SIZE`) or 118 comes from a keepalive-sized probe
+    /// squeaking through an otherwise-blackholing path (symmetric NAT,
+    /// flaky link), which then flaps `minmtu` 0↔tiny and, if used, sends
+    /// real data into a path that can't carry it. Treat sub-`MINMTU` as
+    /// "no usable UDP MTU" (== 0) so the send gate rides TCP / relays
+    /// until discovery proves a genuine MTU. See issue #21.
+    #[must_use]
+    pub(crate) fn usable_minmtu(&self) -> u16 {
+        let m = self.minmtu();
+        if m >= crate::pmtu::MINMTU { m } else { 0 }
+    }
+
     /// `n->maxmtu`.
     #[must_use]
     pub(crate) fn maxmtu(&self) -> u16 {
@@ -451,6 +466,33 @@ mod tests {
         // decide_autoconnect would go negative (saturate to 0) if
         // this reset, masking real relay traffic across a flap.
         assert_eq!(t.relay_tx_bytes, 12345);
+    }
+
+    #[test]
+    fn usable_minmtu_floors_at_minmtu() {
+        use crate::pmtu::{MIN_PROBE_SIZE, MINMTU};
+        let mut t = TunnelState::default();
+        // No pmtu state yet → not usable.
+        assert_eq!(t.usable_minmtu(), 0, "unseeded → 0");
+
+        let set = |t: &mut TunnelState, m: u16| {
+            let mut p = PmtuState::new(Instant::now(), MTU);
+            p.minmtu = m;
+            t.pmtu = Some(p);
+        };
+
+        // Sub-MINMTU values (tiny-probe noise on a blackholing path)
+        // are NOT a usable UDP MTU → reported as 0 so the send gate
+        // rides TCP/relay instead of the dead direct hop.
+        for m in [0, MIN_PROBE_SIZE, 118, MINMTU - 1] {
+            set(&mut t, m);
+            assert_eq!(t.usable_minmtu(), 0, "sub-MINMTU {m} → 0");
+        }
+        // At/above the floor, the real measurement is reported.
+        for m in [MINMTU, 1400, MTU] {
+            set(&mut t, m);
+            assert_eq!(t.usable_minmtu(), m, "usable {m} passes through");
+        }
     }
 
     #[test]

--- a/crates/tincd/src/udp_info.rs
+++ b/crates/tincd/src/udp_info.rs
@@ -337,6 +337,22 @@ pub(crate) fn adjust_mtu_for_send(
     mtu
 }
 
+/// Whether an `MTU_INFO` carrying `mtu` may be put on the wire.
+///
+/// [`on_receive_mtu_info`] treats `mtu < MTU_MIN` (512) as
+/// [`MtuInfoAction::Malformed`], which the daemon turns into a fatal
+/// `BadKey` that tears down the meta connection. A converged direct or
+/// relay PMTU below that floor (e.g. `0` when no probe replies arrive,
+/// or `18` = `MIN_PROBE_SIZE` when only keepalive-sized probes survive a
+/// blackholing path) is a legitimate "UDP is unusable" state, NOT a
+/// value to advertise: emitting it would drop the link and loop
+/// (teardown → SPTPS restart → PMTU re-collapse → re-send). Suppress it;
+/// the peer relies on its own discovery / TCP fallback. See issue #21.
+#[must_use]
+pub(crate) const fn mtu_info_sendable(mtu: i32) -> bool {
+    mtu >= MTU_MIN
+}
+
 /// What to do with a received `MTU_INFO`.
 ///
 /// `N` is the caller's node-id type; forwarding variants carry
@@ -585,6 +601,40 @@ mod tests {
         ];
         for &(label, mtu, via_my, from, via, nh, want) in cases {
             assert_eq!(adjust_mtu_for_send(mtu, via_my, from, via, nh), want, "{label}");
+        }
+    }
+
+    /// The sender must never emit an `MTU_INFO` value the receiver
+    /// rejects as fatal: `mtu_info_sendable` is the exact inverse of the
+    /// `on_receive_mtu_info` `Malformed` gate. A converged sub-512 PMTU
+    /// (0 when no probe replies arrive, 18 = `MIN_PROBE_SIZE` on a
+    /// blackholing path) is therefore suppressed instead of tearing down
+    /// the meta connection. Regression for issue #21.
+    #[test]
+    fn mtu_send_floor_matches_recv_gate() {
+        let unconv = FromMtuState {
+            mtu: 1500,
+            minmtu: 1000,
+            maxmtu: 1500,
+        };
+        // Collapsed values seen in the wild, plus the 511/512 edge.
+        for mtu in [0, 18, 511] {
+            assert!(!mtu_info_sendable(mtu), "sub-512 must be suppressed: {mtu}");
+        }
+        for mtu in [MTU_MIN, 1400, MTU_MAX] {
+            assert!(mtu_info_sendable(mtu), "usable MTU must be sendable: {mtu}");
+        }
+        // Contract: sendable ⇔ receiver does NOT treat it as Malformed.
+        for mtu in [-1, 0, 18, 400, 511, 512, 1400, MTU_MAX, 12000] {
+            let rejected = matches!(
+                on_receive_mtu_info(&mkmtu(mtu), Some(((), unconv)), Some(())),
+                MtuInfoAction::Malformed
+            );
+            assert_eq!(
+                mtu_info_sendable(mtu),
+                !rejected,
+                "sender/receiver contract disagree at mtu={mtu}"
+            );
         }
     }
 


### PR DESCRIPTION
Fixes both facets of the unified root cause in #21: **tincr never enforces `MINMTU` (512) as the UDP-usability threshold**, so an intermittent/degraded UDP path that only passes keepalive-sized probes (symmetric NAT, flaky link) is repeatedly treated as a working direct path.

## Commit 1 — control plane: don't emit sub-512 `MTU_INFO`

A converged direct/relay PMTU below `MTU_MIN` (512) — `0` (no replies) or `18` = `MIN_PROBE_SIZE` — was sent verbatim in `MTU_INFO`. The receiver treats `mtu < 512` as `Malformed` → fatal `BadKey` → **meta-connection teardown**, which loops (teardown → SPTPS restart → PMTU re-collapse → re-send). Observed in production for three nodes on three networks.

Fix: `udp_info::mtu_info_sendable(mtu)` (the exact inverse of the receiver's `Malformed` gate); `send_mtu_info_from` suppresses the send when it fails. Test `mtu_send_floor_matches_recv_gate` locks the sender/receiver contract.

## Commit 2 — data plane: gate UDP on MINMTU usability, not `minmtu > 0`

`send_sptps_data_relay` used any `minmtu > 0` as "UDP works", so `minmtu`=18/118 (tiny-probe noise) attracted real data onto a hop that blackholes it, while PMTU churned `0↔tiny` (~11 `Decrease in PMTU … restarting`/min in production). `MINMTU` is documented as *"below this we don't consider UDP to be working"* but was only used for probe sizing.

Fix: `TunnelState::usable_minmtu()` returns `minmtu` once it reaches `MINMTU`, else `0`; applied at the direct-vs-relay decision and the fast-path atomic mirror (`udp_probe_h` / `apply_meta_udp_confirm`). Below `MINMTU`, data rides TCP/relay until discovery proves a genuine MTU; probes stay exempt so discovery still runs and a real direct path is adopted the moment it appears — no static config, roaming-friendly. Test `usable_minmtu_floors_at_minmtu`.

This is a deliberate divergence from C `net_packet.c:974` (`minmtu > 0`), which lets tiny-probe noise pin real data to a dead direct path.

## Verification
- `cargo test -p tincd --lib` → 644 passed (incl. both new tests).
- `cargo clippy -p tincd --lib` and `cargo fmt -p tincd -- --check` clean.
- `udp_asymmetric` / `tcp_fallback` netns tests unaffected (their confirmed bar is `minmtu` ≥ 1400 > `MINMTU`).

## Still draft — open questions
- Both fixes are the same root; happy to split into two PRs if you prefer.
- **Not yet addressed:** the PMTU *discovery churn itself* — a path that keeps converging sub-`MINMTU` still re-runs discovery every few seconds. A proper fix is exponential backoff on repeated sub-`MINMTU` convergence (declare UDP unusable, slow the re-probe), but that's a larger `PmtuState` change with C-differential implications, so I left it out pending your steer.
- Receiver-tolerance (clamp-and-ignore instead of teardown on `mtu < 512`) as defense-in-depth is also possible but diverges from C protocol semantics.
