### PR TITLE
nix: default services.tincr.package via callPackage in the module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,18 +73,13 @@
           nixos-tinc-dht = pkgs.callPackage ./nix/nixos-test-dht.nix { inherit tincd; };
           nixos-tincr = pkgs.callPackage ./nix/nixos-test-tincr.nix {
             inherit tincd;
-            tincrModule = ./nix/module.nix;
+            tincrModule = self.nixosModules.tincr;
           };
         }
       );
 
       formatter = eachSystem (system: _: treefmt.${system}.config.build.wrapper);
 
-      nixosModules.tincr =
-        { pkgs, ... }:
-        {
-          imports = [ ./nix/module.nix ];
-          services.tincr.package = self.packages.${pkgs.stdenv.hostPlatform.system}.tincd;
-        };
+      nixosModules.tincr = nixpkgs.lib.modules.importApply ./nix/module.nix { inherit crane; };
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,3 +1,4 @@
+{ crane }:
 {
   config,
   lib,
@@ -401,6 +402,10 @@ in
 
     package = mkOption {
       type = types.package;
+      # callPackage splices: under cross-compilation rustc runs on the
+      # build platform instead of a native (emulated) bootstrap.
+      default = pkgs.callPackage ./tincd.nix { craneLib = crane.mkLib pkgs; };
+      defaultText = literalExpression "pkgs.callPackage ./tincd.nix { }";
       description = "Default package used for any network without an explicit `package`.";
     };
   };


### PR DESCRIPTION
The flake pinned the native packages.<system>.tincd; under cross (riscv64 via pkgsCross) that bootstraps rustc under emulation. callPackage splices a cross rustc instead. crane is threaded in with lib.modules.importApply.