### PR TITLE
nix: split socket-activated listeners by address family

### DIFF
--- a/contrib/tincd@.socket
+++ b/contrib/tincd@.socket
@@ -14,8 +14,9 @@
 Description=tinc VPN listen socket (network %i)
 
 [Socket]
-ListenStream=655
-BindIPv6Only=both
+ListenStream=0.0.0.0:655
+ListenStream=[::]:655
+BindIPv6Only=ipv6-only
 # tincd treats every passed fd as a TCP listener; FreeBind lets
 # the bind succeed before the interface address exists at boot.
 FreeBind=yes

--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -1279,11 +1279,13 @@ impl Daemon {
 
         match udp_info::on_receive_mtu_info(&parsed, from, to) {
             MtuInfoAction::Malformed => {
-                // conn-fatal.
-                Err(DispatchError::BadKey(format!(
-                    "MTU_INFO from {conn_name}: invalid MTU {}",
-                    parsed.mtu
-                )))
+                // NOT conn-fatal (deviation from C): unfixed peers
+                // still emit 0/18, and teardown looped one bad hop
+                // into a mesh-wide outage (#21).
+                log::warn!(target: "tincd::proto",
+                           "Ignoring MTU_INFO from {conn_name} with invalid MTU {}",
+                           parsed.mtu);
+                Ok(false)
             }
             MtuInfoAction::UnknownNode => {
                 log::error!(target: "tincd::proto",

--- a/crates/tincd/src/listen.rs
+++ b/crates/tincd/src/listen.rs
@@ -229,16 +229,18 @@ fn apply_common_sockopts(
     domain: Domain,
     opts: &SockOpts,
     label: &str,
+    v6only: bool,
 ) -> io::Result<()> {
     // SO_REUSEADDR: restart after crash without EADDRINUSE from TIME_WAIT.
     if let Err(e) = s.set_reuse_address(true) {
         log::warn!(target: "tincd::net", "SO_REUSEADDR{label}: {e}");
     }
 
-    // IPV6_V6ONLY: load-bearing. Without this the v6 socket grabs v4
-    // traffic via mapped addresses, and the v4 bind sees the port as taken.
+    // IPV6_V6ONLY: load-bearing — without it the v6 socket grabs v4
+    // traffic and the v4 bind sees the port as taken. `v6only = false`
+    // only for UDP paired with an adopted dual-stack fd.
     if domain == Domain::IPV6
-        && let Err(e) = s.set_only_v6(true)
+        && let Err(e) = s.set_only_v6(v6only)
     {
         log::warn!(target: "tincd::net", "IPV6_V6ONLY{label}: {e}");
     }
@@ -280,7 +282,7 @@ fn setup_tcp(addr: &SockAddr, opts: &SockOpts) -> io::Result<Socket> {
     let s = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
     crate::set_nosigpipe(&s);
 
-    apply_common_sockopts(&s, domain, opts, "")?;
+    apply_common_sockopts(&s, domain, opts, "", true)?;
 
     // Socket's Drop closes on failure.
     s.bind(addr)?;
@@ -383,7 +385,10 @@ pub(crate) fn adopt_listeners_from(
         // `ListenDatagram=` would put a UDP fd in the mix, but tinc's
         // protocol pairs TCP+UDP on the SAME addr — easier to open UDP
         // ourselves than to de-interleave systemd's fd list).
-        let udp = setup_udp(&SockAddr::from(local), opts)
+        // Mirror the adopted fd's dual-stackness: v6only here would
+        // make every send to a v4 peer fail with ENETUNREACH.
+        let v6only = local.is_ipv4() || tcp.only_v6().unwrap_or(true);
+        let udp = setup_udp(&SockAddr::from(local), opts, v6only)
             .map_err(|e| io::Error::other(format!("UDP bind for listen fd {tcp_fd}: {e}")))?;
 
         log::info!(target: "tincd::net",
@@ -425,7 +430,7 @@ pub(crate) fn adopt_listeners(n: usize, opts: &SockOpts) -> io::Result<Vec<Liste
 ///
 /// # Errors
 /// `socket`/`bind` errors. `setsockopt` warnings logged.
-fn setup_udp(addr: &SockAddr, opts: &SockOpts) -> io::Result<Socket> {
+fn setup_udp(addr: &SockAddr, opts: &SockOpts, v6only: bool) -> io::Result<Socket> {
     let domain = Domain::from(i32::from(addr.family()));
     let s = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
 
@@ -482,7 +487,7 @@ fn setup_udp(addr: &SockAddr, opts: &SockOpts) -> io::Result<Socket> {
     // REUSEADDR, V6ONLY, SO_MARK, BINDTODEVICE. All pre-bind,
     // idempotent, order-independent; BINDTODEVICE stays last
     // (right before bind).
-    apply_common_sockopts(&s, domain, opts, " (udp)")?;
+    apply_common_sockopts(&s, domain, opts, " (udp)", v6only)?;
 
     s.bind(addr)?;
 
@@ -615,7 +620,7 @@ fn open_one(
         .and_then(|a| a.as_socket())
         .map(|a| a.port());
 
-    let udp = match bind_reusing_port(addr, tcp_port, |sa| setup_udp(sa, opts)) {
+    let udp = match bind_reusing_port(addr, tcp_port, |sa| setup_udp(sa, opts, true)) {
         Ok(s) => s,
         Err(e) => {
             // tcp drops here, fd closes.

--- a/crates/tincd/src/listen/tests.rs
+++ b/crates/tincd/src/listen/tests.rs
@@ -512,6 +512,33 @@ fn adopt_listeners_from_high_fd() {
     );
 }
 
+/// A dual-stack adopted fd (systemd `BindIPv6Only=both`) must yield
+/// a dual-stack UDP socket; forcing v6only made every v4 send fail
+/// with ENETUNREACH.
+#[test]
+fn adopt_dual_stack_fd_yields_dual_stack_udp() {
+    let tcp = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
+    tcp.set_only_v6(false).unwrap();
+    tcp.bind(&"[::]:0".parse::<SocketAddr>().unwrap().into())
+        .unwrap();
+    tcp.listen(1).unwrap();
+
+    let high_fd = nix::unistd::dup(&tcp).expect("dup");
+    drop(tcp);
+    let raw = high_fd.into_raw_fd();
+    let listeners = adopt_listeners_from(raw, 1, &opts()).unwrap();
+
+    assert!(
+        !listeners[0].udp.only_v6().unwrap(),
+        "UDP must inherit the adopted fd's dual-stackness"
+    );
+    // The kernel maps plain-v4 destinations on a dual-stack socket.
+    listeners[0]
+        .udp
+        .send_to(b"x", &"127.0.0.1:9".parse::<SocketAddr>().unwrap().into())
+        .expect("v4 send through dual-stack UDP socket");
+}
+
 /// `n > MAXSOCKETS` is the only pre-adoption guard.
 #[test]
 fn adopt_listeners_too_many() {

--- a/crates/tincd/src/pmtu.rs
+++ b/crates/tincd/src/pmtu.rs
@@ -34,6 +34,11 @@ use crate::daemon::intervals::{PMTU_PROBE_TICK, PMTU_REVALIDATE_TICK};
 /// 1500 bytes payload + 14 ethernet + 4 VLAN.
 pub(crate) const MTU: u16 = 1518;
 /// Below this we don't consider UDP to be working.
+///
+/// Invariant on [`PmtuState::minmtu`]: always `0` or in
+/// `MINMTU..=MTU`. Smaller replies (18-byte keepalives) confirm
+/// liveness but never feed convergence, so a dead path can't
+/// converge at a tiny "usable" value (issue #21).
 pub(crate) const MINMTU: u16 = 512;
 /// eth header (14) + 4 random bytes.
 pub(crate) const MIN_PROBE_SIZE: u16 = 18;
@@ -312,7 +317,7 @@ impl PmtuState {
         if len > self.maxmtu {
             self.maxmtu = len;
         }
-        if len > self.minmtu {
+        if len >= MINMTU && len > self.minmtu {
             self.minmtu = len;
         }
         true
@@ -338,10 +343,11 @@ impl PmtuState {
         self.udp_reply_rx = now;
 
         // PMTU-increase detector. Restart at sent=1 (not 0) so the
-        // maxmtu re-seed doesn't undo this.
+        // maxmtu re-seed doesn't undo this. Tiny replies restart
+        // discovery (path may have healed) with minmtu 0.
         if len > self.maxmtu {
             out.push(PmtuAction::LogIncrease);
-            self.minmtu = len;
+            self.minmtu = if len >= MINMTU { len } else { 0 };
             self.maxmtu = MTU;
             self.phase = PmtuPhase::Discovery { sent: 1 };
             return out;
@@ -354,8 +360,7 @@ impl PmtuState {
             self.mtu_ping_sent = now;
         }
 
-        // Raise minmtu.
-        if self.minmtu < len {
+        if len >= MINMTU && self.minmtu < len {
             self.minmtu = len;
             self.try_fix_mtu(&mut out);
         }
@@ -404,10 +409,13 @@ impl PmtuState {
         };
         if matches!(self.phase, PmtuPhase::Fix) || self.minmtu >= self.maxmtu {
             if self.minmtu > self.maxmtu {
-                self.minmtu = self.maxmtu;
-            } else {
-                self.maxmtu = self.minmtu;
+                self.minmtu = if self.maxmtu >= MINMTU {
+                    self.maxmtu
+                } else {
+                    0
+                };
             }
+            self.maxmtu = self.minmtu;
             self.mtu = self.minmtu;
             out.push(PmtuAction::LogFixed {
                 mtu: self.mtu,
@@ -884,6 +892,80 @@ mod tests {
             s.minmtu,
             MTU
         );
+    }
+
+    // minmtu invariant (issue #21): see MINMTU doc.
+
+    #[test]
+    fn keepalive_reply_does_not_raise_minmtu() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.ping_sent = true;
+        let _ = s.on_probe_reply(MIN_PROBE_SIZE, now);
+        assert!(s.udp_confirmed);
+        assert!(s.udp_ping_rtt.is_some());
+        assert_eq!(s.minmtu, 0, "keepalive reply must not raise minmtu");
+    }
+
+    #[test]
+    fn discovery_timeout_with_only_tiny_replies_fixes_at_zero() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        let pi = Duration::from_secs(60);
+        let mut t = now;
+        for _ in 0..25 {
+            t += Duration::from_secs(1);
+            let _ = s.tick(t, pi);
+            let _ = s.on_probe_reply(MIN_PROBE_SIZE, t);
+        }
+        assert!(
+            s.minmtu == 0 || s.minmtu >= MINMTU,
+            "invariant: {}",
+            s.minmtu
+        );
+        assert_eq!(s.mtu, 0, "unusable path must fix at 0, got {}", s.mtu);
+    }
+
+    #[test]
+    fn increase_detector_gated_on_minmtu_floor() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.minmtu = 0;
+        s.maxmtu = 0;
+        s.mtu = 0;
+        s.phase = PmtuPhase::Steady;
+        let out = s.on_probe_reply(MIN_PROBE_SIZE, now);
+        assert_eq!(out, vec![PmtuAction::LogIncrease]);
+        assert_eq!(s.minmtu, 0);
+        assert_eq!(s.maxmtu, MTU);
+        assert_eq!(s.phase, PmtuPhase::Discovery { sent: 1 });
+    }
+
+    #[test]
+    fn on_meta_ack_small_len_does_not_raise_minmtu() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.ping_sent = true;
+        assert!(s.on_meta_ack(MIN_PROBE_SIZE, now));
+        assert!(s.udp_confirmed);
+        assert_eq!(s.minmtu, 0);
+    }
+
+    #[test]
+    fn try_fix_clamp_down_below_minmtu_is_unusable() {
+        // Peer-raised minmtu above a sub-MINMTU maxmtu.
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.minmtu = 600;
+        s.maxmtu = 431;
+        s.phase = PmtuPhase::Fix;
+        let _ = s.tick(now + Duration::from_secs(1), Duration::from_secs(60));
+        assert!(
+            s.minmtu == 0 || s.minmtu >= MINMTU,
+            "invariant: {}",
+            s.minmtu
+        );
+        assert_eq!(s.mtu, 0);
     }
 
     #[test]

--- a/crates/tincd/src/udp_info.rs
+++ b/crates/tincd/src/udp_info.rs
@@ -70,6 +70,13 @@ impl PmtuSnapshot {
     pub(crate) const fn converged(self) -> bool {
         self.minmtu == self.maxmtu
     }
+
+    /// Converged at a UDP-usable value; `None` = still probing or
+    /// converged at 0 (UDP dead).
+    #[must_use]
+    pub(crate) fn usable_minmtu(self) -> Option<u16> {
+        (self.converged() && self.minmtu >= crate::pmtu::MINMTU).then_some(self.minmtu)
+    }
 }
 
 /// Gates before sending `UDP_INFO`. Returns `true` if the message
@@ -313,25 +320,18 @@ pub(crate) fn adjust_mtu_for_send(
     via_pmtu: Option<PmtuSnapshot>,
     via_nexthop_pmtu: Option<PmtuSnapshot>,
 ) -> i32 {
-    // Converged direct measurement: override entirely. The only branch
-    // that can increase mtu.
-    if from_via_is_myself
-        && let Some(f) = from_pmtu
-        && f.converged()
-    {
-        return i32::from(f.minmtu);
+    // Converged usable direct measurement: override entirely. The
+    // only branch that can increase mtu.
+    if from_via_is_myself && let Some(m) = from_pmtu.and_then(PmtuSnapshot::usable_minmtu) {
+        return i32::from(m);
     }
     // Static relay converged: clamp.
-    if let Some(v) = via_pmtu
-        && v.converged()
-    {
-        return mtu.min(i32::from(v.minmtu));
+    if let Some(m) = via_pmtu.and_then(PmtuSnapshot::usable_minmtu) {
+        return mtu.min(i32::from(m));
     }
     // Dynamic relay's nexthop converged: clamp.
-    if let Some(n) = via_nexthop_pmtu
-        && n.converged()
-    {
-        return mtu.min(i32::from(n.minmtu));
+    if let Some(m) = via_nexthop_pmtu.and_then(PmtuSnapshot::usable_minmtu) {
+        return mtu.min(i32::from(m));
     }
     // No measurement: pass through.
     mtu
@@ -582,6 +582,10 @@ mod tests {
             (":314 via clamp is min not set",   1000, false, None,       conv(1300), None,       1000),
             (":318 via_nexthop clamp",          1500, false, None,       None,       conv(1200), 1200),
             ("unconverged → passthrough",       1400, true,  probe,      probe,      probe,      1400),
+            // #21: converged-at-0 (UDP dead) → passthrough.
+            ("#21 direct converged-at-0",        1400, true,  conv(0),    None,       None,       1400),
+            ("#21 via converged-at-0",           1400, false, None,       conv(0),    None,       1400),
+            ("#21 via_nh converged-at-0",        1400, false, None,       None,       conv(0),    1400),
         ];
         for &(label, mtu, via_my, from, via, nh, want) in cases {
             assert_eq!(adjust_mtu_for_send(mtu, via_my, from, via, nh), want, "{label}");

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -383,8 +383,11 @@ let
     description = "tinc VPN listen socket (network ${netName})";
     wantedBy = [ "sockets.target" ];
     socketConfig = {
-      ListenStream = toString net.listenPort;
-      BindIPv6Only = "both";
+      ListenStream = [
+        "0.0.0.0:${toString net.listenPort}"
+        "[::]:${toString net.listenPort}"
+      ];
+      BindIPv6Only = "ipv6-only";
       FreeBind = true;
     };
   };

--- a/nix/nixos-test-systemd.nix
+++ b/nix/nixos-test-systemd.nix
@@ -60,12 +60,15 @@ let
         };
       };
 
-      # Mirror contrib/tincd@.socket: TCP only, port 655. tincd opens
-      # the paired UDP socket itself against the same address.
+      # Mirror contrib/tincd@.socket: separate TCP listeners ensure tincd
+      # opens paired IPv4 and IPv6 UDP sockets instead of an IPv6-only pair.
       systemd.sockets."tincd@mesh" = {
         wantedBy = [ "sockets.target" ];
-        listenStreams = [ "655" ];
-        socketConfig.BindIPv6Only = "both";
+        listenStreams = [
+          "0.0.0.0:655"
+          "[::]:655"
+        ];
+        socketConfig.BindIPv6Only = "ipv6-only";
       };
 
       # Mirror contrib/tincd@.service.
@@ -160,9 +163,8 @@ testers.runNixOSTest {
             timeout=10,
         )
 
-        # UDP 655 is bound by tincd (not systemd): the daemon opened
-        # it against the adopted TCP addr.
-        beta.succeed("ss -ulnp 'sport = :655' | grep -w tincd")
+        # UDP 655 is bound by tincd (not systemd), once for each family.
+        beta.succeed("test $(ss -H -ulnp 'sport = :655' | grep -cw tincd) -eq 2")
 
     with subtest("data path over the activated listener"):
         alpha.wait_until_succeeds("ping -c1 -W2 10.21.0.2", timeout=30)

--- a/nix/nixos-test-tincr.nix
+++ b/nix/nixos-test-tincr.nix
@@ -96,9 +96,26 @@ testers.runNixOSTest {
         assert "cap_net_admin" not in out.lower(), out
         assert "cap_net_bind_service" in out.lower(), out
 
-    with subtest("data path: ping over the mesh"):
+        for m in (alpha, beta):
+            listeners = m.succeed(
+                "systemctl show -p Listen tincr-mesh.socket"
+            )
+            assert "0.0.0.0:655" in listeners, listeners
+            assert "[::]:655" in listeners, listeners
+
+    with subtest("data path: direct UDP over the mesh"):
+        import re
+
         alpha.wait_until_succeeds("ping -c1 -W2 10.21.0.2", timeout=30)
         beta.succeed("ping -c1 -W2 10.21.0.1")
+        for m, peer in ((alpha, "beta"), (beta, "alpha")):
+            row = m.wait_until_succeeds(
+                "tinc --pidfile=/run/tincr/mesh.pid -n mesh dump nodes "
+                f"| grep '^{peer} '",
+                timeout=30,
+            )
+            status = int(re.search(r"status ([0-9a-f]+)", row).group(1), 16)
+            assert status & 0x80, row
 
     with subtest("DNS stub answers via systemd-resolved per-link routing"):
         for m in (alpha, beta):


### PR DESCRIPTION
A dual-stack TCP listener makes tincd derive only an IPv6 UDP socket, so IPv4 peer sends fail with ENETUNREACH. Pass explicit IPv4 and IPv6 listeners so each adopted TCP socket gets a matching UDP socket.