### PR TITLE
tincd: make sub-MINMTU PMTU convergence unrepresentable

### DIFF
--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -1279,11 +1279,13 @@ impl Daemon {
 
         match udp_info::on_receive_mtu_info(&parsed, from, to) {
             MtuInfoAction::Malformed => {
-                // conn-fatal.
-                Err(DispatchError::BadKey(format!(
-                    "MTU_INFO from {conn_name}: invalid MTU {}",
-                    parsed.mtu
-                )))
+                // NOT conn-fatal (deviation from C): unfixed peers
+                // still emit 0/18, and teardown looped one bad hop
+                // into a mesh-wide outage (#21).
+                log::warn!(target: "tincd::proto",
+                           "Ignoring MTU_INFO from {conn_name} with invalid MTU {}",
+                           parsed.mtu);
+                Ok(false)
             }
             MtuInfoAction::UnknownNode => {
                 log::error!(target: "tincd::proto",

--- a/crates/tincd/src/pmtu.rs
+++ b/crates/tincd/src/pmtu.rs
@@ -34,6 +34,11 @@ use crate::daemon::intervals::{PMTU_PROBE_TICK, PMTU_REVALIDATE_TICK};
 /// 1500 bytes payload + 14 ethernet + 4 VLAN.
 pub(crate) const MTU: u16 = 1518;
 /// Below this we don't consider UDP to be working.
+///
+/// Invariant on [`PmtuState::minmtu`]: always `0` or in
+/// `MINMTU..=MTU`. Smaller replies (18-byte keepalives) confirm
+/// liveness but never feed convergence, so a dead path can't
+/// converge at a tiny "usable" value (issue #21).
 pub(crate) const MINMTU: u16 = 512;
 /// eth header (14) + 4 random bytes.
 pub(crate) const MIN_PROBE_SIZE: u16 = 18;
@@ -312,7 +317,7 @@ impl PmtuState {
         if len > self.maxmtu {
             self.maxmtu = len;
         }
-        if len > self.minmtu {
+        if len >= MINMTU && len > self.minmtu {
             self.minmtu = len;
         }
         true
@@ -338,10 +343,11 @@ impl PmtuState {
         self.udp_reply_rx = now;
 
         // PMTU-increase detector. Restart at sent=1 (not 0) so the
-        // maxmtu re-seed doesn't undo this.
+        // maxmtu re-seed doesn't undo this. Tiny replies restart
+        // discovery (path may have healed) with minmtu 0.
         if len > self.maxmtu {
             out.push(PmtuAction::LogIncrease);
-            self.minmtu = len;
+            self.minmtu = if len >= MINMTU { len } else { 0 };
             self.maxmtu = MTU;
             self.phase = PmtuPhase::Discovery { sent: 1 };
             return out;
@@ -354,8 +360,7 @@ impl PmtuState {
             self.mtu_ping_sent = now;
         }
 
-        // Raise minmtu.
-        if self.minmtu < len {
+        if len >= MINMTU && self.minmtu < len {
             self.minmtu = len;
             self.try_fix_mtu(&mut out);
         }
@@ -404,10 +409,13 @@ impl PmtuState {
         };
         if matches!(self.phase, PmtuPhase::Fix) || self.minmtu >= self.maxmtu {
             if self.minmtu > self.maxmtu {
-                self.minmtu = self.maxmtu;
-            } else {
-                self.maxmtu = self.minmtu;
+                self.minmtu = if self.maxmtu >= MINMTU {
+                    self.maxmtu
+                } else {
+                    0
+                };
             }
+            self.maxmtu = self.minmtu;
             self.mtu = self.minmtu;
             out.push(PmtuAction::LogFixed {
                 mtu: self.mtu,
@@ -884,6 +892,80 @@ mod tests {
             s.minmtu,
             MTU
         );
+    }
+
+    // minmtu invariant (issue #21): see MINMTU doc.
+
+    #[test]
+    fn keepalive_reply_does_not_raise_minmtu() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.ping_sent = true;
+        let _ = s.on_probe_reply(MIN_PROBE_SIZE, now);
+        assert!(s.udp_confirmed);
+        assert!(s.udp_ping_rtt.is_some());
+        assert_eq!(s.minmtu, 0, "keepalive reply must not raise minmtu");
+    }
+
+    #[test]
+    fn discovery_timeout_with_only_tiny_replies_fixes_at_zero() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        let pi = Duration::from_secs(60);
+        let mut t = now;
+        for _ in 0..25 {
+            t += Duration::from_secs(1);
+            let _ = s.tick(t, pi);
+            let _ = s.on_probe_reply(MIN_PROBE_SIZE, t);
+        }
+        assert!(
+            s.minmtu == 0 || s.minmtu >= MINMTU,
+            "invariant: {}",
+            s.minmtu
+        );
+        assert_eq!(s.mtu, 0, "unusable path must fix at 0, got {}", s.mtu);
+    }
+
+    #[test]
+    fn increase_detector_gated_on_minmtu_floor() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.minmtu = 0;
+        s.maxmtu = 0;
+        s.mtu = 0;
+        s.phase = PmtuPhase::Steady;
+        let out = s.on_probe_reply(MIN_PROBE_SIZE, now);
+        assert_eq!(out, vec![PmtuAction::LogIncrease]);
+        assert_eq!(s.minmtu, 0);
+        assert_eq!(s.maxmtu, MTU);
+        assert_eq!(s.phase, PmtuPhase::Discovery { sent: 1 });
+    }
+
+    #[test]
+    fn on_meta_ack_small_len_does_not_raise_minmtu() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.ping_sent = true;
+        assert!(s.on_meta_ack(MIN_PROBE_SIZE, now));
+        assert!(s.udp_confirmed);
+        assert_eq!(s.minmtu, 0);
+    }
+
+    #[test]
+    fn try_fix_clamp_down_below_minmtu_is_unusable() {
+        // Peer-raised minmtu above a sub-MINMTU maxmtu.
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.minmtu = 600;
+        s.maxmtu = 431;
+        s.phase = PmtuPhase::Fix;
+        let _ = s.tick(now + Duration::from_secs(1), Duration::from_secs(60));
+        assert!(
+            s.minmtu == 0 || s.minmtu >= MINMTU,
+            "invariant: {}",
+            s.minmtu
+        );
+        assert_eq!(s.mtu, 0);
     }
 
     #[test]

--- a/crates/tincd/src/udp_info.rs
+++ b/crates/tincd/src/udp_info.rs
@@ -70,6 +70,13 @@ impl PmtuSnapshot {
     pub(crate) const fn converged(self) -> bool {
         self.minmtu == self.maxmtu
     }
+
+    /// Converged at a UDP-usable value; `None` = still probing or
+    /// converged at 0 (UDP dead).
+    #[must_use]
+    pub(crate) fn usable_minmtu(self) -> Option<u16> {
+        (self.converged() && self.minmtu >= crate::pmtu::MINMTU).then_some(self.minmtu)
+    }
 }
 
 /// Gates before sending `UDP_INFO`. Returns `true` if the message
@@ -313,25 +320,18 @@ pub(crate) fn adjust_mtu_for_send(
     via_pmtu: Option<PmtuSnapshot>,
     via_nexthop_pmtu: Option<PmtuSnapshot>,
 ) -> i32 {
-    // Converged direct measurement: override entirely. The only branch
-    // that can increase mtu.
-    if from_via_is_myself
-        && let Some(f) = from_pmtu
-        && f.converged()
-    {
-        return i32::from(f.minmtu);
+    // Converged usable direct measurement: override entirely. The
+    // only branch that can increase mtu.
+    if from_via_is_myself && let Some(m) = from_pmtu.and_then(PmtuSnapshot::usable_minmtu) {
+        return i32::from(m);
     }
     // Static relay converged: clamp.
-    if let Some(v) = via_pmtu
-        && v.converged()
-    {
-        return mtu.min(i32::from(v.minmtu));
+    if let Some(m) = via_pmtu.and_then(PmtuSnapshot::usable_minmtu) {
+        return mtu.min(i32::from(m));
     }
     // Dynamic relay's nexthop converged: clamp.
-    if let Some(n) = via_nexthop_pmtu
-        && n.converged()
-    {
-        return mtu.min(i32::from(n.minmtu));
+    if let Some(m) = via_nexthop_pmtu.and_then(PmtuSnapshot::usable_minmtu) {
+        return mtu.min(i32::from(m));
     }
     // No measurement: pass through.
     mtu
@@ -582,6 +582,10 @@ mod tests {
             (":314 via clamp is min not set",   1000, false, None,       conv(1300), None,       1000),
             (":318 via_nexthop clamp",          1500, false, None,       None,       conv(1200), 1200),
             ("unconverged → passthrough",       1400, true,  probe,      probe,      probe,      1400),
+            // #21: converged-at-0 (UDP dead) → passthrough.
+            ("#21 direct converged-at-0",        1400, true,  conv(0),    None,       None,       1400),
+            ("#21 via converged-at-0",           1400, false, None,       conv(0),    None,       1400),
+            ("#21 via_nh converged-at-0",        1400, false, None,       None,       conv(0),    1400),
         ];
         for &(label, mtu, via_my, from, via, nh, want) in cases {
             assert_eq!(adjust_mtu_for_send(mtu, via_my, from, via, nh), want, "{label}");


### PR DESCRIPTION
Keepalive-sized (18-byte) probe replies raised minmtu, so a path that only passes tiny packets converged at 18. That selected UDP for data on a blackholing hop and leaked MTU_INFO 0/18, which receivers treat as conn-fatal, looping into mesh-wide meta teardowns (#21).

Enforce the invariant minmtu in {0} u [MINMTU, MTU]: sub-MINMTU replies confirm liveness but never feed convergence, so a dead path converges at 0 (= go-TCP). Emission reads converged values only via PmtuSnapshot::usable_minmtu(), so sub-512 MTU_INFO cannot be built. Malformed MTU_INFO is now dropped instead of tearing down the conn, since unfixed senders stay in the field.

Fixes #21