### PR TITLE
net: harden Darwin UDP egress and PMTU accounting

### DIFF
--- a/crates/tinc-device/Cargo.toml
+++ b/crates/tinc-device/Cargo.toml
@@ -51,7 +51,7 @@ nix = { version = "0.31", default-features = false, features = ["ioctl", "fs"] }
 # (CAP_NET_ADMIN, not root, is what matters; the daemon checks
 # capabilities via `nix::sys::capability` or just lets the open
 # fail with EACCES). The test skip is the only consumer.
-nix = { version = "0.31", default-features = false, features = ["user", "fs"] }
+nix = { version = "0.31", default-features = false, features = ["user", "fs", "event"] }
 
 [lints]
 workspace = true

--- a/crates/tinc-device/src/bsd/macos_x.rs
+++ b/crates/tinc-device/src/bsd/macos_x.rs
@@ -265,11 +265,25 @@ impl UtunBatch {
     }
 
     /// Ship all staged frames via one `sendmsg_x`. No-op when empty.
-    /// On `ENOSYS` latches `disabled` and replays via per-frame
-    /// `write(2)` so nothing is lost; on `ENOBUFS`/partial send the
-    /// unsent tail is dropped (utun inject is best-effort — same
-    /// semantics as a full TUN txq under the per-packet path).
+    /// A short positive return is an accepted prefix; replay only the
+    /// unsent tail with bounded per-packet writes.
     pub(super) fn flush(&mut self, fd: BorrowedFd<'_>) -> io::Result<()> {
+        self.flush_with(fd, |fd, hdrs, count, flags| {
+            // SAFETY: `flush_with` initialized `hdrs[..count]`; each
+            // iovec points into the live persistent write buffer.
+            let ret = unsafe { sendmsg_x(fd, hdrs, count, flags) };
+            if ret < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                usize::try_from(ret).map_err(io::Error::other)
+            }
+        })
+    }
+
+    fn flush_with<F>(&mut self, fd: BorrowedFd<'_>, submit: F) -> io::Result<()>
+    where
+        F: FnOnce(libc::c_int, *const MsghdrX, libc::c_uint, libc::c_int) -> io::Result<usize>,
+    {
         let n = std::mem::take(&mut self.wcount);
         if n == 0 {
             return Ok(());
@@ -297,31 +311,108 @@ impl UtunBatch {
         }
         // n ≤ STRIDE = 64.
         #[allow(clippy::cast_possible_truncation)]
-        let cnt = n as libc::c_uint;
-        // SAFETY: `hdrs[..n]` fully initialised above; each iovec is
-        // within `self.wbuf` which we exclusively own. fd is the utun
-        // socket borrowed from the owning `BsdTun`.
-        let ret = unsafe { sendmsg_x(fd.as_raw_fd(), self.hdrs.as_ptr(), cnt, libc::MSG_DONTWAIT) };
-        if ret >= 0 {
-            return Ok(());
-        }
-        let err = io::Error::last_os_error();
-        match err.raw_os_error() {
-            Some(libc::ENOSYS) => {
-                self.disabled = true;
-                // Replay so this batch isn't lost; subsequent calls
-                // go straight to per-packet `write()`.
-                for i in 0..n {
-                    let off = i * WRITE_SLOT;
-                    let len = usize::from(self.wlens[i]);
-                    let _ = nix::unistd::write(fd, &self.wbuf[off..off + len]);
-                }
-                Ok(())
+        let count = n as libc::c_uint;
+        let first_unsent = match submit(
+            fd.as_raw_fd(),
+            self.hdrs.as_ptr(),
+            count,
+            libc::MSG_DONTWAIT,
+        ) {
+            Ok(accepted) if accepted <= n => accepted,
+            Ok(accepted) => {
+                return Err(io::Error::other(format!(
+                    "sendmsg_x reported {accepted} datagrams for a {n}-datagram batch"
+                )));
             }
-            // sndbuf full: same as per-packet `ENOBUFS` — drop, the
-            // inner transport retransmits.
-            Some(libc::ENOBUFS | libc::EAGAIN) => Ok(()),
-            _ => Err(err),
+            Err(err) if err.raw_os_error() == Some(libc::ENOSYS) => {
+                self.disabled = true;
+                0
+            }
+            // A batch can make no progress when its aggregate request
+            // hits the socket limit. Per-packet fallback may still fit.
+            Err(err) if matches!(err.raw_os_error(), Some(libc::ENOBUFS | libc::EAGAIN)) => 0,
+            Err(err) => return Err(err),
+        };
+
+        for i in first_unsent..n {
+            let off = i * WRITE_SLOT;
+            let len = usize::from(self.wlens[i]);
+            match nix::unistd::write(fd, &self.wbuf[off..off + len]) {
+                Ok(written) if written == len => {}
+                Ok(written) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        format!("utun wrote {written} of {len} bytes"),
+                    ));
+                }
+                // Best effort, matching the existing per-packet utun
+                // behavior. Never spin in the single-threaded daemon.
+                Err(nix::errno::Errno::ENOBUFS | nix::errno::Errno::EAGAIN) => {}
+                Err(err) => return Err(err.into()),
+            }
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsFd;
+    use std::os::unix::net::UnixDatagram;
+
+    use super::*;
+
+    fn frame(marker: u8) -> Vec<u8> {
+        let mut frame = vec![0u8; ETH_HLEN + 20];
+        frame[12..14].copy_from_slice(&0x0800u16.to_be_bytes());
+        frame[ETH_HLEN] = 0x45;
+        frame[ETH_HLEN + 1] = marker;
+        frame
+    }
+
+    fn assert_markers(rx: &UnixDatagram, expected: &[u8]) {
+        let mut buf = [0u8; 64];
+        for marker in expected {
+            let n = rx.recv(&mut buf).unwrap();
+            assert_eq!(&buf[..4], &(libc::AF_INET as u32).to_be_bytes());
+            assert_eq!(buf[5], *marker);
+            assert_eq!(n, AF_PREFIX_LEN + 20);
+        }
+    }
+
+    #[test]
+    fn flush_replays_partial_tail() {
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let mut batch = UtunBatch::new();
+        for marker in 1..=4 {
+            assert!(batch.stage(&frame(marker)));
+        }
+
+        batch
+            .flush_with(tx.as_fd(), |fd, hdrs, _count, flags| {
+                // SAFETY: `flush_with` initialized four headers. The
+                // real syscall accepts the first two as one batch.
+                let sent = unsafe { sendmsg_x(fd, hdrs, 2, flags) };
+                assert_eq!(sent, 2);
+                Ok(2)
+            })
+            .unwrap();
+
+        assert_markers(&rx, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn flush_replays_zero_progress_once() {
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let mut batch = UtunBatch::new();
+        for marker in 1..=3 {
+            assert!(batch.stage(&frame(marker)));
+        }
+
+        batch
+            .flush_with(tx.as_fd(), |_fd, _hdrs, _count, _flags| Ok(0))
+            .unwrap();
+
+        assert_markers(&rx, &[1, 2, 3]);
     }
 }

--- a/crates/tinc-device/src/bsd/macos_x.rs
+++ b/crates/tinc-device/src/bsd/macos_x.rs
@@ -265,11 +265,11 @@ impl UtunBatch {
     }
 
     /// Ship all staged frames via one `sendmsg_x`. No-op when empty.
-    /// A short positive return is an accepted prefix; replay only the
+    /// A short positive return is an accepted prefix. Replay only the
     /// unsent tail with bounded per-packet writes.
     pub(super) fn flush(&mut self, fd: BorrowedFd<'_>) -> io::Result<()> {
         self.flush_with(fd, |fd, hdrs, count, flags| {
-            // SAFETY: `flush_with` initialized `hdrs[..count]`; each
+            // SAFETY: `flush_with` initialized `hdrs[..count]`. Each
             // iovec points into the live persistent write buffer.
             let ret = unsafe { sendmsg_x(fd, hdrs, count, flags) };
             if ret < 0 {
@@ -328,8 +328,7 @@ impl UtunBatch {
                 self.disabled = true;
                 0
             }
-            // A batch can make no progress when its aggregate request
-            // hits the socket limit. Per-packet fallback may still fit.
+            // Zero progress. Per-packet fallback may still fit.
             Err(err) if matches!(err.raw_os_error(), Some(libc::ENOBUFS | libc::EAGAIN)) => 0,
             Err(err) => return Err(err),
         };
@@ -345,8 +344,7 @@ impl UtunBatch {
                         format!("utun wrote {written} of {len} bytes"),
                     ));
                 }
-                // Best effort, matching the existing per-packet utun
-                // behavior. Never spin in the single-threaded daemon.
+                // Best-effort drop, same as the per-packet path.
                 Err(nix::errno::Errno::ENOBUFS | nix::errno::Errno::EAGAIN) => {}
                 Err(err) => return Err(err.into()),
             }
@@ -390,8 +388,7 @@ mod tests {
 
         batch
             .flush_with(tx.as_fd(), |fd, hdrs, _count, flags| {
-                // SAFETY: `flush_with` initialized four headers. The
-                // real syscall accepts the first two as one batch.
+                // SAFETY: four headers initialized. Send only two.
                 let sent = unsafe { sendmsg_x(fd, hdrs, 2, flags) };
                 assert_eq!(sent, 2);
                 Ok(2)

--- a/crates/tinc-device/tests/utun_batch.rs
+++ b/crates/tinc-device/tests/utun_batch.rs
@@ -9,9 +9,12 @@
 #![cfg(target_os = "macos")]
 
 use std::net::UdpSocket;
+use std::os::fd::AsRawFd;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+use nix::sys::event::{EvFlags, EventFilter, FilterFlag, KEvent, Kqueue};
+use nix::sys::time::TimeSpec;
 use tinc_device::{BsdTun, Device, DeviceArena, DrainResult};
 
 fn ifconfig(iface: &str, local: &str, peer: &str) {
@@ -76,6 +79,66 @@ fn utun_recvmsg_x_drain() {
         assert_eq!(f[14], 0x45, "IPv4");
         assert_eq!(f[14 + 28], 0xA0 + u8::try_from(i).unwrap(), "payload");
     }
+}
+
+#[test]
+fn utun_partial_drain_refires_kqueue() {
+    if !nix::unistd::geteuid().is_root() {
+        eprintln!("SKIP utun_partial_drain_refires_kqueue: needs root");
+        return;
+    }
+    let (local, peer) = ("10.98.3.1", "10.98.3.2");
+    let mut dev = BsdTun::open_utun(None).expect("open_utun");
+    ifconfig(dev.iface(), local, peer);
+
+    let fd = dev.fd().expect("utun fd").as_raw_fd();
+    let kq = Kqueue::new().expect("kqueue");
+    let change = KEvent::new(
+        usize::try_from(fd).unwrap(),
+        EventFilter::EVFILT_READ,
+        EvFlags::EV_ADD,
+        FilterFlag::empty(),
+        0,
+        0,
+    );
+    kq.kevent(&[change], &mut [], None).expect("register utun");
+
+    let tx = UdpSocket::bind((local, 0)).expect("bind");
+    for marker in 0..128u8 {
+        tx.send_to(&[marker; 32], (peer, 40001))
+            .expect("queue utun packet");
+    }
+
+    let empty = KEvent::new(
+        0,
+        EventFilter::EVFILT_READ,
+        EvFlags::empty(),
+        FilterFlag::empty(),
+        0,
+        0,
+    );
+    let mut events = [empty];
+    let timeout = *TimeSpec::from_duration(Duration::from_secs(1)).as_ref();
+    assert_eq!(kq.kevent(&[], &mut events, Some(timeout)).unwrap(), 1);
+
+    let mut arena = DeviceArena::new(64);
+    assert_eq!(
+        dev.drain(&mut arena, 64).unwrap(),
+        DrainResult::Frames { count: 64 }
+    );
+
+    // Plain EV_ADD is level-triggered. Sixty-four queued packets
+    // remain, so returning to kevent must report readability again.
+    let immediate = *TimeSpec::from_duration(Duration::from_millis(50)).as_ref();
+    assert_eq!(
+        kq.kevent(&[], &mut events, Some(immediate)).unwrap(),
+        1,
+        "utun still has queued packets after the capped drain"
+    );
+    assert!(matches!(
+        dev.drain(&mut arena, 64).unwrap(),
+        DrainResult::Frames { count: 1..=64 }
+    ));
 }
 
 #[test]

--- a/crates/tincd/src/daemon/gossip/keys.rs
+++ b/crates/tincd/src/daemon/gossip/keys.rs
@@ -98,7 +98,9 @@ impl Daemon {
                     ));
                 } else {
                     // start() emits one Wire; defensive.
-                    nw |= self.send_sptps_data(to_nid, tinc_sptps::REC_HANDSHAKE, &bytes);
+                    nw |= self
+                        .send_sptps_data(to_nid, tinc_sptps::REC_HANDSHAKE, &bytes)
+                        .needs_write;
                 }
             }
         }
@@ -187,7 +189,9 @@ impl Daemon {
             log::debug!(target: "tincd::proto",
                             "Relaying SPTPS_PACKET {} → {} ({} bytes)",
                             msg.from, msg.to, data.len());
-            let mut nw = self.send_sptps_data_relay(to_nid, from_nid, 0, Some(&data));
+            let mut nw = self
+                .send_sptps_data_relay(to_nid, from_nid, 0, Some(&data))
+                .needs_write;
             nw |= self.try_tx(to_nid, true);
             return Some(nw);
         }
@@ -352,7 +356,9 @@ impl Daemon {
                 }
             };
             // `to.via == myself` trivially holds for `to == myself`.
-            let mut nw = self.dispatch_tunnel_outputs(from_nid, &msg.from, outs);
+            let mut nw = self
+                .dispatch_tunnel_outputs(from_nid, &msg.from, outs)
+                .needs_write;
             nw |= self.send_mtu_info(from_nid, &msg.from, i32::from(MTU), true);
             nw |= self.send_udp_info(from_nid, &msg.from, true);
             return Ok(nw);
@@ -482,10 +488,14 @@ impl Daemon {
         // send_sptps_data, no init special-case). receive(init's
         // KEX) just stashes - recv_outs is empty here.
         let mut nw = hint_nw;
-        nw |= self.dispatch_tunnel_outputs(from_nid, &msg.from, init_outs);
+        nw |= self
+            .dispatch_tunnel_outputs(from_nid, &msg.from, init_outs)
+            .needs_write;
         match recv_result {
             Ok((_consumed, recv_outs)) => {
-                nw |= self.dispatch_tunnel_outputs(from_nid, &msg.from, recv_outs);
+                nw |= self
+                    .dispatch_tunnel_outputs(from_nid, &msg.from, recv_outs)
+                    .needs_write;
             }
             Err(e) => {
                 log::error!(target: "tincd::proto",
@@ -636,7 +646,9 @@ impl Daemon {
             }
         };
 
-        let mut nw = self.dispatch_tunnel_outputs(from_nid, &msg.from, outs);
+        let mut nw = self
+            .dispatch_tunnel_outputs(from_nid, &msg.from, outs)
+            .needs_write;
 
         // Two gates - validkey (set above on HandshakeDone; without
         // it the addr could be a replay) + relay appended one.

--- a/crates/tincd/src/daemon/metaconn.rs
+++ b/crates/tincd/src/daemon/metaconn.rs
@@ -841,7 +841,9 @@ impl Daemon {
                             "Relaying SPTPS_PACKET {from_name} → {} \
                              ({} bytes)",
                             self.node_log_name(to_nid), ct.len());
-                nw |= self.send_sptps_data_relay(to_nid, from_nid, 0, Some(ct));
+                nw |= self
+                    .send_sptps_data_relay(to_nid, from_nid, 0, Some(ct))
+                    .needs_write;
             }
             nw |= self.try_tx(to_nid, true);
             return nw;
@@ -874,7 +876,9 @@ impl Daemon {
                 return nw;
             }
         };
-        nw |= self.dispatch_tunnel_outputs(from_nid, &from_name, outs);
+        nw |= self
+            .dispatch_tunnel_outputs(from_nid, &from_name, outs)
+            .needs_write;
         // Tell upstream relays our MTU floor.
         nw |= self.send_mtu_info(from_nid, &from_name, i32::from(MTU), true);
         nw

--- a/crates/tincd/src/daemon/net.rs
+++ b/crates/tincd/src/daemon/net.rs
@@ -12,6 +12,7 @@ mod icmp;
 mod route;
 mod rx;
 mod sptps;
+pub(in crate::daemon) use sptps::TunnelSendOutcome;
 
 pub use rx::MAX_PENDING_META;
 

--- a/crates/tincd/src/daemon/net/rx.rs
+++ b/crates/tincd/src/daemon/net/rx.rs
@@ -597,7 +597,9 @@ impl Daemon {
             }
         }
 
-        let nw = self.dispatch_tunnel_outputs(from_nid, &from_name, outs);
+        let nw = self
+            .dispatch_tunnel_outputs(from_nid, &from_name, outs)
+            .needs_write;
         // Clear udppacket (deferred, see above).
         if let Some(t) = self.dp.tunnels.get_mut(&from_nid) {
             t.status.udppacket = false;
@@ -663,7 +665,9 @@ impl Daemon {
                         "Relaying UDP packet from {from_name} to {} \
                          ({} bytes)",
                         self.node_log_name(to_nid), ct.len());
-            let mut nw = self.send_sptps_data_relay(to_nid, from_nid, 0, Some(ct));
+            let mut nw = self
+                .send_sptps_data_relay(to_nid, from_nid, 0, Some(ct))
+                .needs_write;
             nw |= self.try_tx(to_nid, true);
             if nw {
                 self.maybe_set_write_any();

--- a/crates/tincd/src/daemon/net/sptps.rs
+++ b/crates/tincd/src/daemon/net/sptps.rs
@@ -12,6 +12,21 @@ use crate::graph::NodeId;
 use rand_core::OsRng;
 use tinc_proto::Request;
 
+/// Transport result kept separate from the historical "meta socket
+/// needs write readiness" boolean.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(in crate::daemon) struct TunnelSendOutcome {
+    pub(in crate::daemon) needs_write: bool,
+    pub(in crate::daemon) udp_sent: bool,
+}
+
+impl TunnelSendOutcome {
+    fn merge(&mut self, other: Self) {
+        self.needs_write |= other.needs_write;
+        self.udp_sent |= other.udp_sent;
+    }
+}
+
 impl Daemon {
     /// Router strips the eth header (receiver re-synthesizes from
     /// IP version nibble).
@@ -132,12 +147,22 @@ impl Daemon {
         peer_name: &str,
         outs: Vec<tinc_sptps::Output>,
     ) -> bool {
+        self.dispatch_tunnel_outputs_outcome(peer, peer_name, outs)
+            .needs_write
+    }
+
+    pub(in crate::daemon) fn dispatch_tunnel_outputs_outcome(
+        &mut self,
+        peer: NodeId,
+        peer_name: &str,
+        outs: Vec<tinc_sptps::Output>,
+    ) -> TunnelSendOutcome {
         use tinc_sptps::Output;
-        let mut nw = false;
+        let mut outcome = TunnelSendOutcome::default();
         for o in outs {
             match o {
                 Output::Wire { record_type, bytes } => {
-                    nw |= self.send_sptps_data(peer, record_type, &bytes);
+                    outcome.merge(self.send_sptps_data_outcome(peer, record_type, &bytes));
                 }
                 Output::HandshakeDone => {
                     let tunnel = self.dp.tunnels.entry(peer).or_default();
@@ -206,11 +231,11 @@ impl Daemon {
                     self.dp.rx_scratch.clear();
                     self.dp.rx_scratch.resize(14, 0);
                     self.dp.rx_scratch.extend_from_slice(&bytes);
-                    nw |= self.receive_sptps_record(peer, peer_name, record_type);
+                    outcome.needs_write |= self.receive_sptps_record(peer, peer_name, record_type);
                 }
             }
         }
-        nw
+        outcome
     }
 
     /// Decode, decompress (if needed) and route one SPTPS record.
@@ -396,7 +421,17 @@ impl Daemon {
         record_type: u8,
         ct: &[u8],
     ) -> bool {
-        self.send_sptps_data_relay(to_nid, self.myself, record_type, Some(ct))
+        self.send_sptps_data_outcome(to_nid, record_type, ct)
+            .needs_write
+    }
+
+    fn send_sptps_data_outcome(
+        &mut self,
+        to_nid: NodeId,
+        record_type: u8,
+        ct: &[u8],
+    ) -> TunnelSendOutcome {
+        self.send_sptps_data_relay_outcome(to_nid, self.myself, record_type, Some(ct))
     }
 
     /// Relay decision: TCP vs UDP, `via` vs `nexthop`.
@@ -525,6 +560,17 @@ impl Daemon {
         record_type: u8,
         ct: Option<&[u8]>,
     ) -> bool {
+        self.send_sptps_data_relay_outcome(to_nid, from_nid, record_type, ct)
+            .needs_write
+    }
+
+    fn send_sptps_data_relay_outcome(
+        &mut self,
+        to_nid: NodeId,
+        from_nid: NodeId,
+        record_type: u8,
+        ct: Option<&[u8]>,
+    ) -> TunnelSendOutcome {
         // `ct` is None on the hot path: SPTPS frame at
         // tx_scratch[12..] from seal_data_into. Some(ct): relay/
         // handshake/probe path. origlen is plaintext body length
@@ -536,7 +582,7 @@ impl Daemon {
             log::debug!(target: "tincd::net",
                         "No route to {}; dropping",
                         self.node_log_name(to_nid));
-            return false;
+            return TunnelSendOutcome::default();
         };
         let via_nid = route.via;
         let nexthop_nid = route.nexthop;
@@ -599,7 +645,10 @@ impl Daemon {
         }
 
         if go_tcp {
-            return self.send_sptps_tcp(to_nid, from_nid, record_type, ct, from_is_myself);
+            return TunnelSendOutcome {
+                needs_write: self.send_sptps_tcp(to_nid, from_nid, record_type, ct, from_is_myself),
+                udp_sent: false,
+            };
         }
 
         // We always prefix (peers are ≥1.1). direct ⇒ dst=nullid.
@@ -641,7 +690,7 @@ impl Daemon {
                 log::debug!(target: "tincd::net",
                             "No UDP address known for relay {}; dropping",
                             self.node_log_name(relay_nid));
-                return false;
+                return TunnelSendOutcome::default();
             };
             cold_sockaddr = socket2::SockAddr::from(addr);
             (&cold_sockaddr, sock)
@@ -680,30 +729,33 @@ impl Daemon {
             }
             dp.tx_batch
                 .stage(sockaddr, sock, relay_nid, at_len, &dp.tx_scratch);
-            return false; // staged; UDP send doesn't touch outbuf
+            return TunnelSendOutcome::default(); // staged; no meta write or immediate UDP send
         }
 
         // Immediate-send path. Hit when: outside the drain loop,
         // OR cold path (no cached addr), OR relay/
         // handshake (`ct.is_some()`).
-        self.send_sptps_udp_immediate(sockaddr, sock, relay_nid, origlen);
-        false // UDP send doesn't touch any meta-conn outbuf
+        TunnelSendOutcome {
+            needs_write: false,
+            udp_sent: self.send_sptps_udp_immediate(sockaddr, sock, relay_nid, origlen),
+        }
     }
 
     /// Single-frame UDP send for [`Self::send_sptps_data_relay`].
     /// `count=1` means `stride == last_len`; both `Portable` and
-    /// `linux::Fast` skip GSO. Handles `EMSGSIZE` → PMTU shrink.
+    /// `linux::Fast` skip GSO. Returns true only when the local UDP
+    /// socket accepted the datagram. Handles `EMSGSIZE` → PMTU shrink.
     fn send_sptps_udp_immediate(
         &mut self,
         sockaddr: &socket2::SockAddr,
         sock: u8,
         relay_nid: NodeId,
         origlen: usize,
-    ) {
+    ) -> bool {
         #[expect(clippy::cast_possible_truncation)] // tx_scratch ≤ MTU+33+12 < u16::MAX
         let len = self.dp.tx_scratch.len() as u16;
         let Some(slot) = self.listeners.get_mut(usize::from(sock)) else {
-            return;
+            return false;
         };
         let Err(e) = slot.egress.send_batch(&crate::egress::EgressBatch {
             dst: sockaddr,
@@ -712,7 +764,7 @@ impl Daemon {
             count: 1,
             last_len: len,
         }) else {
-            return;
+            return true;
         };
         if e.kind() == io::ErrorKind::WouldBlock {
             // Drop; UDP is unreliable.
@@ -741,6 +793,7 @@ impl Daemon {
             log::warn!(target: "tincd::net",
                        "Error sending UDP SPTPS packet to {relay_name}: {e}");
         }
+        false
     }
 }
 

--- a/crates/tincd/src/daemon/net/sptps.rs
+++ b/crates/tincd/src/daemon/net/sptps.rs
@@ -12,8 +12,8 @@ use crate::graph::NodeId;
 use rand_core::OsRng;
 use tinc_proto::Request;
 
-/// Transport result kept separate from the historical "meta socket
-/// needs write readiness" boolean.
+/// Per-send result: meta-socket write readiness + whether the local
+/// UDP socket accepted a datagram.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(in crate::daemon) struct TunnelSendOutcome {
     pub(in crate::daemon) needs_write: bool,
@@ -137,21 +137,12 @@ impl Daemon {
             return false;
         }
         self.send_sptps_data_relay(to_nid, self.myself, record_type, None)
+            .needs_write
     }
 
     /// SPTPS callback bridge. SPTPS returns Vec<Output> so this is
     /// both the `receive_sptps_record` and `send_sptps_data` sides.
     pub(in crate::daemon) fn dispatch_tunnel_outputs(
-        &mut self,
-        peer: NodeId,
-        peer_name: &str,
-        outs: Vec<tinc_sptps::Output>,
-    ) -> bool {
-        self.dispatch_tunnel_outputs_outcome(peer, peer_name, outs)
-            .needs_write
-    }
-
-    pub(in crate::daemon) fn dispatch_tunnel_outputs_outcome(
         &mut self,
         peer: NodeId,
         peer_name: &str,
@@ -162,7 +153,7 @@ impl Daemon {
         for o in outs {
             match o {
                 Output::Wire { record_type, bytes } => {
-                    outcome.merge(self.send_sptps_data_outcome(peer, record_type, &bytes));
+                    outcome.merge(self.send_sptps_data(peer, record_type, &bytes));
                 }
                 Output::HandshakeDone => {
                     let tunnel = self.dp.tunnels.entry(peer).or_default();
@@ -420,18 +411,8 @@ impl Daemon {
         to_nid: NodeId,
         record_type: u8,
         ct: &[u8],
-    ) -> bool {
-        self.send_sptps_data_outcome(to_nid, record_type, ct)
-            .needs_write
-    }
-
-    fn send_sptps_data_outcome(
-        &mut self,
-        to_nid: NodeId,
-        record_type: u8,
-        ct: &[u8],
     ) -> TunnelSendOutcome {
-        self.send_sptps_data_relay_outcome(to_nid, self.myself, record_type, Some(ct))
+        self.send_sptps_data_relay(to_nid, self.myself, record_type, Some(ct))
     }
 
     /// Relay decision: TCP vs UDP, `via` vs `nexthop`.
@@ -554,17 +535,6 @@ impl Daemon {
     /// `from_nid`: ORIGINAL source. For relay forwarding it's the
     /// original sender's `NodeId` — wire prefix carries THEIR `src_id6`.
     pub(in crate::daemon) fn send_sptps_data_relay(
-        &mut self,
-        to_nid: NodeId,
-        from_nid: NodeId,
-        record_type: u8,
-        ct: Option<&[u8]>,
-    ) -> bool {
-        self.send_sptps_data_relay_outcome(to_nid, from_nid, record_type, ct)
-            .needs_write
-    }
-
-    fn send_sptps_data_relay_outcome(
         &mut self,
         to_nid: NodeId,
         from_nid: NodeId,

--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use super::net::TunnelSendOutcome;
 use super::{ConnId, Daemon, PKT_PROBE, TimerWhat, parse_subnets_from_config};
 
 use std::collections::HashSet;
@@ -185,7 +186,12 @@ impl Daemon {
 
     /// Build and send a PROBE request of `len` bytes. byte[0]=0
     /// (request), bytes[1..14]=zero, bytes[14..len]=random.
-    pub(super) fn send_udp_probe(&mut self, peer: NodeId, peer_name: &str, len: u16) -> bool {
+    fn send_udp_probe_outcome(
+        &mut self,
+        peer: NodeId,
+        peer_name: &str,
+        len: u16,
+    ) -> TunnelSendOutcome {
         let len = len.max(pmtu::MIN_PROBE_SIZE);
         let mut body = vec![0u8; usize::from(len)];
         // zero[0..14], random[14..]. The 14-byte zero prefix is
@@ -197,28 +203,38 @@ impl Daemon {
 
         log::debug!(target: "tincd::net",
                     "Sending UDP probe length {len} to {peer_name}");
-        self.send_probe_record(peer, peer_name, &body)
+        self.send_probe_record_outcome(peer, peer_name, &body)
     }
 
     /// Shared path for probe requests and replies.
     pub(super) fn send_probe_record(&mut self, peer: NodeId, peer_name: &str, body: &[u8]) -> bool {
+        self.send_probe_record_outcome(peer, peer_name, body)
+            .needs_write
+    }
+
+    fn send_probe_record_outcome(
+        &mut self,
+        peer: NodeId,
+        peer_name: &str,
+        body: &[u8],
+    ) -> TunnelSendOutcome {
         let tunnel = self.dp.tunnels.entry(peer).or_default();
         if !tunnel.status.validkey {
-            return false;
+            return TunnelSendOutcome::default();
         }
         let Some(sptps) = tunnel.sptps.as_deref_mut() else {
-            return false;
+            return TunnelSendOutcome::default();
         };
         let outs = match sptps.send_record(PKT_PROBE, body) {
             Ok(outs) => outs,
             Err(e) => {
                 log::debug!(target: "tincd::net",
                             "Probe send_record for {peer_name}: {e:?}");
-                return false;
+                return TunnelSendOutcome::default();
             }
         };
         // relay decision always prefers `via` for PKT_PROBE.
-        self.dispatch_tunnel_outputs(peer, peer_name, outs)
+        self.dispatch_tunnel_outputs_outcome(peer, peer_name, outs)
     }
 
     /// The "improve the tunnel" tick. Called from TWO places:
@@ -341,8 +357,19 @@ impl Daemon {
                     Self::log_pmtu_action(&target_name, a);
                 }
                 for a in actions {
-                    if let PmtuAction::SendProbe { len } = a {
-                        nw |= self.send_udp_probe(target, &target_name, len);
+                    if let PmtuAction::SendProbe { len, counts_miss } = a {
+                        let outcome = self.send_udp_probe_outcome(target, &target_name, len);
+                        nw |= outcome.needs_write;
+                        if counts_miss
+                            && outcome.udp_sent
+                            && let Some(pmtu) = self
+                                .dp
+                                .tunnels
+                                .get_mut(&target)
+                                .and_then(|t| t.pmtu.as_mut())
+                        {
+                            pmtu.on_counted_probe_sent();
+                        }
                     }
                 }
             }
@@ -373,7 +400,7 @@ impl Daemon {
     }
 
     /// Probe-request send + gratuitous-reply keepalive. Gated on
-    /// `udp_ping_sent` elapsed: 2s when not confirmed (aggressive
+    /// the last local attempt: 2s when not confirmed (aggressive
     /// discovery), 10s when confirmed (NAT keepalive).
     pub(super) fn try_udp(&mut self, target: NodeId, target_name: &str, now: Instant) -> bool {
         if !self.settings.udp_discovery {
@@ -447,14 +474,14 @@ impl Daemon {
         } else {
             self.settings.udp_discovery_interval
         };
-        let elapsed = now.duration_since(p.udp_ping_sent);
-        if elapsed >= Duration::from_secs(u64::from(interval)) {
-            // Fresh Instant::now() for the RTT stamp only — the cadence gate
-            // above keeps using the cached loop clock to avoid
-            // per-packet clock_gettime().
-            p.udp_ping_sent = Instant::now();
-            p.ping_sent = true;
-            nw |= self.send_udp_probe(target, target_name, pmtu::MIN_PROBE_SIZE);
+        if p.udp_probe_due(now, Duration::from_secs(u64::from(interval))) {
+            // Fresh clock only for a submitted probe's RTT stamp; the
+            // cadence gate uses the cached loop clock.
+            let attempted_at = Instant::now();
+            let outcome = self.send_udp_probe_outcome(target, target_name, pmtu::MIN_PROBE_SIZE);
+            nw |= outcome.needs_write;
+            let mut sent = outcome.udp_sent;
+
             // localdiscovery && !udp_confirmed && has_prevedge.
             // send_locally is a side-channel to choose_udp_address;
             // no early-return between set/clear.
@@ -469,11 +496,22 @@ impl Daemon {
                     if let Some(t) = self.dp.tunnels.get_mut(&target) {
                         t.status.send_locally = true;
                     }
-                    nw |= self.send_udp_probe(target, target_name, pmtu::MIN_PROBE_SIZE);
+                    let local =
+                        self.send_udp_probe_outcome(target, target_name, pmtu::MIN_PROBE_SIZE);
+                    nw |= local.needs_write;
+                    sent |= local.udp_sent;
                     if let Some(t) = self.dp.tunnels.get_mut(&target) {
                         t.status.send_locally = false;
                     }
                 }
+            }
+            if let Some(p) = self
+                .dp
+                .tunnels
+                .get_mut(&target)
+                .and_then(|t| t.pmtu.as_mut())
+            {
+                p.on_udp_probe_attempt(attempted_at, sent);
             }
         }
 

--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -181,17 +181,12 @@ impl Daemon {
         log::debug!(target: "tincd::net",
                     "Sending type 2 probe reply length {len} to {peer_name}");
 
-        self.send_probe_record(peer, peer_name, &body)
+        self.send_probe_record(peer, peer_name, &body).needs_write
     }
 
     /// Build and send a PROBE request of `len` bytes. byte[0]=0
     /// (request), bytes[1..14]=zero, bytes[14..len]=random.
-    fn send_udp_probe_outcome(
-        &mut self,
-        peer: NodeId,
-        peer_name: &str,
-        len: u16,
-    ) -> TunnelSendOutcome {
+    fn send_udp_probe(&mut self, peer: NodeId, peer_name: &str, len: u16) -> TunnelSendOutcome {
         let len = len.max(pmtu::MIN_PROBE_SIZE);
         let mut body = vec![0u8; usize::from(len)];
         // zero[0..14], random[14..]. The 14-byte zero prefix is
@@ -203,16 +198,11 @@ impl Daemon {
 
         log::debug!(target: "tincd::net",
                     "Sending UDP probe length {len} to {peer_name}");
-        self.send_probe_record_outcome(peer, peer_name, &body)
+        self.send_probe_record(peer, peer_name, &body)
     }
 
     /// Shared path for probe requests and replies.
-    pub(super) fn send_probe_record(&mut self, peer: NodeId, peer_name: &str, body: &[u8]) -> bool {
-        self.send_probe_record_outcome(peer, peer_name, body)
-            .needs_write
-    }
-
-    fn send_probe_record_outcome(
+    pub(super) fn send_probe_record(
         &mut self,
         peer: NodeId,
         peer_name: &str,
@@ -234,7 +224,7 @@ impl Daemon {
             }
         };
         // relay decision always prefers `via` for PKT_PROBE.
-        self.dispatch_tunnel_outputs_outcome(peer, peer_name, outs)
+        self.dispatch_tunnel_outputs(peer, peer_name, outs)
     }
 
     /// The "improve the tunnel" tick. Called from TWO places:
@@ -358,7 +348,7 @@ impl Daemon {
                 }
                 for a in actions {
                     if let PmtuAction::SendProbe { len, counts_miss } = a {
-                        let outcome = self.send_udp_probe_outcome(target, &target_name, len);
+                        let outcome = self.send_udp_probe(target, &target_name, len);
                         nw |= outcome.needs_write;
                         if counts_miss
                             && outcome.udp_sent
@@ -478,7 +468,7 @@ impl Daemon {
             // Fresh clock only for a submitted probe's RTT stamp; the
             // cadence gate uses the cached loop clock.
             let attempted_at = Instant::now();
-            let outcome = self.send_udp_probe_outcome(target, target_name, pmtu::MIN_PROBE_SIZE);
+            let outcome = self.send_udp_probe(target, target_name, pmtu::MIN_PROBE_SIZE);
             nw |= outcome.needs_write;
             let mut sent = outcome.udp_sent;
 
@@ -496,8 +486,7 @@ impl Daemon {
                     if let Some(t) = self.dp.tunnels.get_mut(&target) {
                         t.status.send_locally = true;
                     }
-                    let local =
-                        self.send_udp_probe_outcome(target, target_name, pmtu::MIN_PROBE_SIZE);
+                    let local = self.send_udp_probe(target, target_name, pmtu::MIN_PROBE_SIZE);
                     nw |= local.needs_write;
                     sent |= local.udp_sent;
                     if let Some(t) = self.dp.tunnels.get_mut(&target) {

--- a/crates/tincd/src/egress/macos.rs
+++ b/crates/tincd/src/egress/macos.rs
@@ -136,9 +136,7 @@ impl Fast {
         ) {
             Ok(accepted) if accepted == usize::from(b.count) => Ok(()),
             Ok(accepted) if accepted < usize::from(b.count) => {
-                // A positive short return accepted the prefix. Replay
-                // only the unsent tail through bounded per-datagram
-                // `sendto` calls; never retry the batch syscall.
+                // Short return: prefix accepted. Replay only the tail.
                 let offset = accepted * stride;
                 let tail = EgressBatch {
                     dst: b.dst,
@@ -154,8 +152,6 @@ impl Fast {
                 b.count
             ))),
             Err(err) if err.raw_os_error() == Some(libc::ENOSYS) => {
-                // The private syscall is documented as unstable. Stop
-                // trying it and replay the complete batch unchanged.
                 self.disabled = true;
                 self.fallback.send_batch(b)
             }
@@ -167,8 +163,8 @@ impl Fast {
 impl UdpEgress for Fast {
     fn send_batch(&mut self, b: &EgressBatch<'_>) -> io::Result<()> {
         self.send_batch_with(b, |sock, hdrs, count, flags| {
-            // SAFETY: `send_batch_with` initialized `hdrs[..count]`;
-            // each iovec borrows the live batch for this call.
+            // SAFETY: `send_batch_with` initialized `hdrs[..count]`.
+            // Each iovec borrows the live batch for this call.
             let ret = unsafe { sendmsg_x(sock, hdrs, count, flags) };
             if ret < 0 {
                 Err(io::Error::last_os_error())
@@ -234,8 +230,7 @@ mod tests {
         assert_eq!(&buf[..n], b"yyyyyyyyyy");
     }
 
-    /// A short positive return accepted only a prefix. The portable
-    /// fallback must send exactly the remaining tail.
+    /// Short return: fallback must send exactly the remaining tail.
     #[test]
     fn macos_fast_replays_partial_tail() {
         let rx = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -252,8 +247,7 @@ mod tests {
         };
 
         p.send_batch_with(&batch, |sock, hdrs, _count, flags| {
-            // SAFETY: the helper initialized all three headers. Limit
-            // the real syscall to two to force a deterministic tail.
+            // SAFETY: three headers initialized. Send only two.
             let ret = unsafe { sendmsg_x(sock, hdrs, 2, flags) };
             assert_eq!(ret, 2);
             Ok(2)
@@ -267,8 +261,7 @@ mod tests {
         }
     }
 
-    /// Zero progress is also bounded: skip the batch syscall result
-    /// and replay every datagram once through the portable path.
+    /// Zero progress: replay every datagram once via the fallback.
     #[test]
     fn macos_fast_replays_zero_progress() {
         let rx = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/crates/tincd/src/egress/macos.rs
+++ b/crates/tincd/src/egress/macos.rs
@@ -83,8 +83,11 @@ impl Fast {
     }
 }
 
-impl UdpEgress for Fast {
-    fn send_batch(&mut self, b: &EgressBatch<'_>) -> io::Result<()> {
+impl Fast {
+    fn send_batch_with<F>(&mut self, b: &EgressBatch<'_>, submit: F) -> io::Result<()>
+    where
+        F: FnOnce(libc::c_int, *const MsghdrX, libc::c_uint, libc::c_int) -> io::Result<usize>,
+    {
         // Single frame: `sendmsg_x` saves nothing over `sendto`.
         if self.disabled || b.count <= 1 || usize::from(b.count) > HDR_CAP {
             return self.fallback.send_batch(b);
@@ -125,37 +128,54 @@ impl UdpEgress for Fast {
             };
         }
 
-        // SAFETY: `hdrs[..count]` fully initialized above; `sock` is
-        // the listener dup we own. `MSG_DONTWAIT` is belt-and-
-        // suspenders: the dup shares `O_NONBLOCK` with the listener.
-        let ret = unsafe {
-            sendmsg_x(
-                sock,
-                self.hdrs.as_ptr(),
-                libc::c_uint::from(b.count),
-                libc::MSG_DONTWAIT,
-            )
-        };
-        if ret >= 0 {
-            // Partial send (`ret < count`) means sndbuf filled mid-
-            // batch. The unsent tail is dropped — same semantics as
-            // `Portable` hitting `WouldBlock` per-frame, and as
-            // `linux::Fast`'s all-or-nothing GSO send. UDP is
-            // unreliable; inner-TCP retransmits.
-            return Ok(());
-        }
-        let err = io::Error::last_os_error();
-        match err.raw_os_error() {
-            // Kernel doesn't implement it (never observed on 10.10+
-            // for UDP, but the header says "subject to change").
-            // Latch off and replay this batch via the portable path
-            // so no frames are lost.
-            Some(libc::ENOSYS) => {
+        match submit(
+            sock,
+            self.hdrs.as_ptr(),
+            libc::c_uint::from(b.count),
+            libc::MSG_DONTWAIT,
+        ) {
+            Ok(accepted) if accepted == usize::from(b.count) => Ok(()),
+            Ok(accepted) if accepted < usize::from(b.count) => {
+                // A positive short return accepted the prefix. Replay
+                // only the unsent tail through bounded per-datagram
+                // `sendto` calls; never retry the batch syscall.
+                let offset = accepted * stride;
+                let tail = EgressBatch {
+                    dst: b.dst,
+                    frames: &b.frames[offset..],
+                    stride: b.stride,
+                    count: b.count - u16::try_from(accepted).expect("accepted < u16 count"),
+                    last_len: b.last_len,
+                };
+                self.fallback.send_batch(&tail)
+            }
+            Ok(accepted) => Err(io::Error::other(format!(
+                "sendmsg_x reported {accepted} datagrams for a {}-datagram batch",
+                b.count
+            ))),
+            Err(err) if err.raw_os_error() == Some(libc::ENOSYS) => {
+                // The private syscall is documented as unstable. Stop
+                // trying it and replay the complete batch unchanged.
                 self.disabled = true;
                 self.fallback.send_batch(b)
             }
-            _ => Err(err),
+            Err(err) => Err(err),
         }
+    }
+}
+
+impl UdpEgress for Fast {
+    fn send_batch(&mut self, b: &EgressBatch<'_>) -> io::Result<()> {
+        self.send_batch_with(b, |sock, hdrs, count, flags| {
+            // SAFETY: `send_batch_with` initialized `hdrs[..count]`;
+            // each iovec borrows the live batch for this call.
+            let ret = unsafe { sendmsg_x(sock, hdrs, count, flags) };
+            if ret < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                usize::try_from(ret).map_err(io::Error::other)
+            }
+        })
     }
 }
 
@@ -212,6 +232,66 @@ mod tests {
         assert_eq!(&buf[..n], b"xxxxxxxxxx");
         let (n, _) = rx.recv_from(&mut buf).unwrap();
         assert_eq!(&buf[..n], b"yyyyyyyyyy");
+    }
+
+    /// A short positive return accepted only a prefix. The portable
+    /// fallback must send exactly the remaining tail.
+    #[test]
+    fn macos_fast_replays_partial_tail() {
+        let rx = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let dst = SockAddr::from(rx.local_addr().unwrap());
+        let tx: Socket = UdpSocket::bind("127.0.0.1:0").unwrap().into();
+        let mut p = Fast::new(&tx).unwrap();
+        let frames = *b"AAAAAAAABBBBBBBBCCCCCCCC";
+        let batch = EgressBatch {
+            dst: &dst,
+            frames: &frames,
+            stride: 8,
+            count: 3,
+            last_len: 8,
+        };
+
+        p.send_batch_with(&batch, |sock, hdrs, _count, flags| {
+            // SAFETY: the helper initialized all three headers. Limit
+            // the real syscall to two to force a deterministic tail.
+            let ret = unsafe { sendmsg_x(sock, hdrs, 2, flags) };
+            assert_eq!(ret, 2);
+            Ok(2)
+        })
+        .unwrap();
+
+        let mut buf = [0u8; 16];
+        for expected in [b"AAAAAAAA", b"BBBBBBBB", b"CCCCCCCC"] {
+            let (n, _) = rx.recv_from(&mut buf).unwrap();
+            assert_eq!(&buf[..n], expected);
+        }
+    }
+
+    /// Zero progress is also bounded: skip the batch syscall result
+    /// and replay every datagram once through the portable path.
+    #[test]
+    fn macos_fast_replays_zero_progress() {
+        let rx = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let dst = SockAddr::from(rx.local_addr().unwrap());
+        let tx: Socket = UdpSocket::bind("127.0.0.1:0").unwrap().into();
+        let mut p = Fast::new(&tx).unwrap();
+        let frames = *b"11112222";
+        let batch = EgressBatch {
+            dst: &dst,
+            frames: &frames,
+            stride: 4,
+            count: 2,
+            last_len: 4,
+        };
+
+        p.send_batch_with(&batch, |_sock, _hdrs, _count, _flags| Ok(0))
+            .unwrap();
+
+        let mut buf = [0u8; 8];
+        for expected in [b"1111", b"2222"] {
+            let (n, _) = rx.recv_from(&mut buf).unwrap();
+            assert_eq!(&buf[..n], expected);
+        }
     }
 
     /// `count == 1` takes the portable `sendto` fallback, not

--- a/crates/tincd/src/lib.rs
+++ b/crates/tincd/src/lib.rs
@@ -64,7 +64,6 @@ mod tcp_tunnel;
 mod tunnel;
 mod udp_info;
 #[cfg(target_os = "linux")]
-pub use platform::set_int_sockopt;
 pub(crate) use platform::{
     bind_to_interface, msg_nosignal, set_cloexec, set_nosigpipe, set_udp_tos, sock_cloexec_flag,
 };

--- a/crates/tincd/src/listen.rs
+++ b/crates/tincd/src/listen.rs
@@ -451,9 +451,8 @@ fn setup_udp(addr: &SockAddr, opts: &SockOpts, v6only: bool) -> io::Result<Socke
         log::warn!(target: "tincd::net", "SO_BROADCAST: {e}");
     }
 
-    // IP_MTU_DISCOVER / IPV6_MTU_DISCOVER = PMTUDISC_DO.
-    // Linux-only: forces DF on every datagram for PMTU discovery.
-    // macOS sets DF by default on UDP sockets.
+    // PMTU probes must reach the underlay as one datagram. Linux and
+    // macOS use different socket options to disable IP fragmentation.
     #[cfg(target_os = "linux")]
     {
         let (level, optname, optval, label) = if domain == Domain::IPV6 {
@@ -472,6 +471,23 @@ fn setup_udp(addr: &SockAddr, opts: &SockOpts, v6only: bool) -> io::Result<Socke
             )
         };
         if let Err(e) = set_int_sockopt(s.as_fd(), level, optname, optval) {
+            log::warn!(target: "tincd::net", "{label}: {e}");
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let (label, result) = if domain == Domain::IPV6 {
+            (
+                "IPV6_DONTFRAG",
+                setsockopt(&s.as_fd(), sockopt::Ipv6DontFrag, &true),
+            )
+        } else {
+            (
+                "IP_DONTFRAG",
+                setsockopt(&s.as_fd(), sockopt::IpDontFrag, &true),
+            )
+        };
+        if let Err(e) = result {
             log::warn!(target: "tincd::net", "{label}: {e}");
         }
     }

--- a/crates/tincd/src/listen.rs
+++ b/crates/tincd/src/listen.rs
@@ -17,7 +17,6 @@ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 
 use crate::bind_to_interface;
 #[cfg(target_os = "linux")]
-use crate::set_int_sockopt;
 use nix::sys::socket::{setsockopt, sockopt};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
@@ -105,8 +104,7 @@ where
     }
 }
 
-/// Raw `getsockopt` sibling of [`set_int_sockopt`]. Test-only readback
-/// for `IP_MTU_DISCOVER`/`IPV6_MTU_DISCOVER`.
+/// Test-only readback for `IP_MTU_DISCOVER`/`IPV6_MTU_DISCOVER`.
 #[cfg(all(test, target_os = "linux"))]
 pub(crate) fn get_int_sockopt(
     fd: BorrowedFd<'_>,
@@ -451,46 +449,7 @@ fn setup_udp(addr: &SockAddr, opts: &SockOpts, v6only: bool) -> io::Result<Socke
         log::warn!(target: "tincd::net", "SO_BROADCAST: {e}");
     }
 
-    // PMTU probes must reach the underlay as one datagram. Linux and
-    // macOS use different socket options to disable IP fragmentation.
-    #[cfg(target_os = "linux")]
-    {
-        let (level, optname, optval, label) = if domain == Domain::IPV6 {
-            (
-                libc::IPPROTO_IPV6,
-                libc::IPV6_MTU_DISCOVER,
-                libc::IPV6_PMTUDISC_DO,
-                "IPV6_MTU_DISCOVER",
-            )
-        } else {
-            (
-                libc::IPPROTO_IP,
-                libc::IP_MTU_DISCOVER,
-                libc::IP_PMTUDISC_DO,
-                "IP_MTU_DISCOVER",
-            )
-        };
-        if let Err(e) = set_int_sockopt(s.as_fd(), level, optname, optval) {
-            log::warn!(target: "tincd::net", "{label}: {e}");
-        }
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let (label, result) = if domain == Domain::IPV6 {
-            (
-                "IPV6_DONTFRAG",
-                setsockopt(&s.as_fd(), sockopt::Ipv6DontFrag, &true),
-            )
-        } else {
-            (
-                "IP_DONTFRAG",
-                setsockopt(&s.as_fd(), sockopt::IpDontFrag, &true),
-            )
-        };
-        if let Err(e) = result {
-            log::warn!(target: "tincd::net", "{label}: {e}");
-        }
-    }
+    crate::platform::set_udp_dontfrag(&s, domain == Domain::IPV6);
 
     // SO_RCVBUF/SO_SNDBUF via `set_udp_buffer`. Default 1MB each.
     // Best-effort.

--- a/crates/tincd/src/listen/tests.rs
+++ b/crates/tincd/src/listen/tests.rs
@@ -1,6 +1,10 @@
 use super::*;
 use nix::fcntl::{FcntlArg, FdFlag, OFlag, fcntl};
 use nix::sys::socket::getsockopt;
+#[cfg(target_os = "macos")]
+use socket2::SockAddr;
+#[cfg(target_os = "macos")]
+use tinc_device::{BsdTun, Device, DeviceArena, DrainResult};
 
 /// Shorthand for tests that don't care about sockopts.
 fn opts() -> SockOpts {
@@ -242,6 +246,65 @@ fn open_udp_pmtudisc_do() {
             libc::IPV6_PMTUDISC_DO,
         );
     }
+}
+
+/// `setup_udp` disables IP fragmentation on macOS so PMTU probes
+/// measure the path instead of succeeding as reassembled fragments.
+#[test]
+#[cfg(target_os = "macos")]
+fn open_udp_dontfrag() {
+    let listeners = open_listeners(0, AddrFamily::Ipv4, &opts());
+    assert!(
+        getsockopt(&listeners[0].udp.as_fd(), sockopt::IpDontFrag).unwrap(),
+        "IP_DONTFRAG not enabled"
+    );
+
+    let listeners6 = open_listeners(0, AddrFamily::Ipv6, &opts());
+    if let Some(l) = listeners6.first() {
+        assert!(
+            getsockopt(&l.udp.as_fd(), sockopt::Ipv6DontFrag).unwrap(),
+            "IPV6_DONTFRAG not enabled"
+        );
+    }
+}
+
+/// A real MTU-1500 utun underlay must reject an oversized UDP
+/// datagram instead of surfacing IP fragments to the interface.
+#[test]
+#[cfg(target_os = "macos")]
+fn open_udp_dontfrag_blocks_underlay_fragments() {
+    if !nix::unistd::geteuid().is_root() {
+        eprintln!("SKIP open_udp_dontfrag_blocks_underlay_fragments: needs root");
+        return;
+    }
+
+    let mut dev = BsdTun::open_utun(None).expect("open_utun");
+    let status = std::process::Command::new("ifconfig")
+        .args([
+            dev.iface(),
+            "inet",
+            "10.98.4.1",
+            "10.98.4.2",
+            "mtu",
+            "1500",
+            "up",
+        ])
+        .status()
+        .expect("ifconfig");
+    assert!(status.success(), "ifconfig {} failed", dev.iface());
+
+    let listeners = open_listeners(0, AddrFamily::Ipv4, &opts());
+    let dst = SockAddr::from(addr("10.98.4.2", 40002));
+    let err = listeners[0]
+        .udp
+        .send_to(&vec![0u8; 1500], &dst)
+        .expect_err("MTU-1500 underlay must reject a 1528-byte IP datagram");
+    assert_eq!(err.raw_os_error(), Some(libc::EMSGSIZE));
+
+    // A fragmented send would make the utun readable. The DF failure
+    // happens before enqueue, leaving no packet for the underlay.
+    let mut arena = DeviceArena::new(1);
+    assert_eq!(dev.drain(&mut arena, 1).unwrap(), DrainResult::Empty);
 }
 
 /// Second listener pair on the same port: TCP bind fails (REUSEADDR

--- a/crates/tincd/src/platform.rs
+++ b/crates/tincd/src/platform.rs
@@ -71,14 +71,14 @@ pub(crate) fn msg_nosignal() -> nix::sys::socket::MsgFlags {
 
 /// Raw `setsockopt` for `c_int`-valued options that neither nix nor
 /// socket2 wrap. After routing TOS/TCLASS/`BOUND_IF` through socket2
-/// the only remaining caller is `IP{,V6}_MTU_DISCOVER` in `listen.rs`
-/// (Linux-only), so this is gated to keep the unsafe surface minimal
-/// on other targets.
+/// the only remaining caller is `IP{,V6}_MTU_DISCOVER` in
+/// [`set_udp_dontfrag`] (Linux-only), so this is gated to keep the
+/// unsafe surface minimal on other targets.
 ///
 /// # Errors
 /// `last_os_error()` from `setsockopt(2)`.
 #[cfg(target_os = "linux")]
-pub fn set_int_sockopt(
+fn set_int_sockopt(
     fd: impl AsFd,
     level: libc::c_int,
     optname: libc::c_int,
@@ -158,6 +158,57 @@ pub(crate) fn bind_to_interface(s: &Socket, iface: &str) -> io::Result<()> {
         s.bind_device_by_index_v4(Some(ifindex))
     };
     res.map_err(|e| io::Error::other(format!("Can't bind to interface {iface}: {e}")))
+}
+
+/// Disable IP fragmentation so PMTU probes reach the underlay as one
+/// datagram. Best-effort: warn only. Linux has no `DONTFRAG` toggle.
+/// `PMTUDISC_DO` sets DF and fails oversized sends with `EMSGSIZE`.
+#[cfg(target_os = "linux")]
+pub(crate) fn set_udp_dontfrag(s: &Socket, ipv6: bool) {
+    let (label, result) = if ipv6 {
+        (
+            "IPV6_MTU_DISCOVER",
+            set_int_sockopt(
+                s.as_fd(),
+                libc::IPPROTO_IPV6,
+                libc::IPV6_MTU_DISCOVER,
+                libc::IPV6_PMTUDISC_DO,
+            ),
+        )
+    } else {
+        (
+            "IP_MTU_DISCOVER",
+            set_int_sockopt(
+                s.as_fd(),
+                libc::IPPROTO_IP,
+                libc::IP_MTU_DISCOVER,
+                libc::IP_PMTUDISC_DO,
+            ),
+        )
+    };
+    if let Err(e) = result {
+        log::warn!(target: "tincd::net", "{label}: {e}");
+    }
+}
+
+/// macOS: `IP{,V6}_DONTFRAG` sets DF without the kernel PMTU cache.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn set_udp_dontfrag(s: &Socket, ipv6: bool) {
+    use nix::sys::socket::{setsockopt, sockopt};
+    let (label, result) = if ipv6 {
+        (
+            "IPV6_DONTFRAG",
+            setsockopt(&s.as_fd(), sockopt::Ipv6DontFrag, &true),
+        )
+    } else {
+        (
+            "IP_DONTFRAG",
+            setsockopt(&s.as_fd(), sockopt::IpDontFrag, &true),
+        )
+    };
+    if let Err(e) = result {
+        log::warn!(target: "tincd::net", "{label}: {e}");
+    }
 }
 
 /// `daemon(3)`: fork, parent `_exit(0)`, child `setsid()` and

--- a/crates/tincd/src/pmtu.rs
+++ b/crates/tincd/src/pmtu.rs
@@ -17,7 +17,7 @@
 //! | `-4` | `Lost` | Reset → `Discovery{0}` |
 //!
 //! Events: `Tick` (driven by `try_tx`, ~1/sec), `ProbeReply{len}`,
-//! `Emsgsize{at_len}`. Actions: `SendProbe{len}`,
+//! `Emsgsize{at_len}`. Actions: `SendProbe{len, counts_miss}`,
 //! `LogFixed{mtu, after_probes}`, `LogReset`.
 //!
 //! EMSGSIZE feedback is asynchronous: `tick()` returns ONE probe,
@@ -65,8 +65,8 @@ pub(crate) enum PmtuPhase {
     /// `mtuprobes == -1`. Probe `maxmtu` (+ `maxmtu+1` increase
     /// detector) every `pinginterval`.
     Steady,
-    /// `mtuprobes ∈ -2..=-3`. `misses` = unanswered steady-state
-    /// probes (1 or 2). One `maxmtu` probe/sec.
+    /// `mtuprobes ∈ -2..=-3`. `misses` = successfully submitted,
+    /// unanswered steady-state probes (1 or 2). One `maxmtu` probe/sec.
     Revalidate { misses: u8 },
     /// `mtuprobes == -4`. Next `tick()` resets to `Discovery{0}`.
     Lost,
@@ -99,6 +99,9 @@ pub(crate) struct PmtuState {
     /// A keepalive probe is outstanding — next reply is the RTT
     /// measurement.
     pub ping_sent: bool,
+    /// Last local probe attempt, including failed submissions. Kept
+    /// separate from `udp_ping_sent`, which timestamps actual sends.
+    pub udp_probe_attempted_at: Instant,
     pub udp_ping_sent: Instant,
     /// Last time a probe **reply** arrived. Diagnostic only —
     /// [`Self::udp_timed_out`] gates on `ping_sent`/`udp_ping_sent`
@@ -114,7 +117,9 @@ pub(crate) struct PmtuState {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PmtuAction {
     /// Send a UDP probe. `len` already clamped to `>= MIN_PROBE_SIZE`.
-    SendProbe { len: u16 },
+    /// `counts_miss` marks the known-good `maxmtu` revalidation probe;
+    /// its successful submission advances the miss state separately.
+    SendProbe { len: u16, counts_miss: bool },
 
     /// Log "Fixing MTU of %s to %d after %d probes". `probes` = how
     /// many discovery probes were sent before converging (0..=20;
@@ -149,11 +154,29 @@ impl PmtuState {
             phase: PmtuPhase::Discovery { sent: 0 },
             udp_confirmed: false,
             ping_sent: false,
+            udp_probe_attempted_at: now,
             udp_ping_sent: now,
             udp_reply_rx: now,
             mtu_ping_sent: now,
             maxrecentlen: 0,
             udp_ping_rtt: None,
+        }
+    }
+
+    /// Whether the UDP-discovery sender should emit a probe now.
+    /// Failed submissions retain the configured retry cadence.
+    #[must_use]
+    pub(crate) fn udp_probe_due(&self, now: Instant, interval: Duration) -> bool {
+        now.saturating_duration_since(self.udp_probe_attempted_at) >= interval
+    }
+
+    /// Record one local probe submission attempt. Failed submissions
+    /// pace retries but do not manufacture an outstanding remote probe.
+    pub(crate) const fn on_udp_probe_attempt(&mut self, now: Instant, sent: bool) {
+        self.udp_probe_attempted_at = now;
+        if sent {
+            self.udp_ping_sent = now;
+            self.ping_sent = true;
         }
     }
 
@@ -224,12 +247,13 @@ impl PmtuState {
         }
 
         // Steady / re-validate: probe maxmtu, in Steady also maxmtu+1
-        // (increase detector). Each unanswered cycle counts a miss; a
-        // maxmtu reply rewinds to Steady (on_probe_reply).
+        // (increase detector). A successful maxmtu submission later
+        // commits the miss; a reply rewinds to Steady.
         match self.phase {
             PmtuPhase::Steady => {
                 out.push(PmtuAction::SendProbe {
                     len: self.maxmtu.max(MIN_PROBE_SIZE),
+                    counts_miss: true,
                 });
                 // saturating: maxmtu is fed from peer-influenced
                 // paths (on_meta_ack/on_probe_reply) — those clamp,
@@ -237,19 +261,15 @@ impl PmtuState {
                 if self.maxmtu.saturating_add(1) < MTU {
                     out.push(PmtuAction::SendProbe {
                         len: self.maxmtu.saturating_add(1),
+                        counts_miss: false,
                     });
                 }
-                self.phase = PmtuPhase::Revalidate { misses: 1 };
             }
-            PmtuPhase::Revalidate { misses } => {
+            PmtuPhase::Revalidate { .. } => {
                 out.push(PmtuAction::SendProbe {
                     len: self.maxmtu.max(MIN_PROBE_SIZE),
+                    counts_miss: true,
                 });
-                self.phase = if misses >= 2 {
-                    PmtuPhase::Lost
-                } else {
-                    PmtuPhase::Revalidate { misses: misses + 1 }
-                };
             }
             // Lost was reset above; Fix was consumed by try_fix_mtu.
             PmtuPhase::Lost | PmtuPhase::Fix => unreachable!(),
@@ -259,6 +279,7 @@ impl PmtuState {
                 let len = probe_size(self.minmtu, self.maxmtu, sent);
                 out.push(PmtuAction::SendProbe {
                     len: len.max(MIN_PROBE_SIZE),
+                    counts_miss: false,
                 });
                 // Probe #20 ends discovery.
                 self.phase = if sent + 1 >= 20 {
@@ -269,6 +290,18 @@ impl PmtuState {
             }
         }
         out
+    }
+
+    /// Commit one unanswered known-`maxmtu` probe after the UDP
+    /// datagram was accepted by the local socket. Failed submissions
+    /// leave the phase unchanged and are retried at normal cadence.
+    pub(crate) const fn on_counted_probe_sent(&mut self) {
+        self.phase = match self.phase {
+            PmtuPhase::Steady => PmtuPhase::Revalidate { misses: 1 },
+            PmtuPhase::Revalidate { misses } if misses >= 2 => PmtuPhase::Lost,
+            PmtuPhase::Revalidate { misses } => PmtuPhase::Revalidate { misses: misses + 1 },
+            phase => phase,
+        };
     }
 
     /// Meta-channel probe ack (`MTU_INFO` 4th field, Rust extension).
@@ -512,7 +545,9 @@ mod tests {
         let mut s = PmtuState::new(now, MTU);
         let out = s.tick(now, Duration::from_secs(60));
         assert_eq!(out.len(), 1);
-        assert!(matches!(out[0], PmtuAction::SendProbe { len } if (1329..=1330).contains(&len)));
+        assert!(
+            matches!(out[0], PmtuAction::SendProbe { len, .. } if (1329..=1330).contains(&len))
+        );
         assert_eq!(s.phase, PmtuPhase::Discovery { sent: 1 });
     }
 
@@ -544,8 +579,13 @@ mod tests {
         let out = s.tick(now + Duration::from_secs(2), Duration::from_secs(60));
         assert_eq!(s.mtu, 1400);
         assert_eq!(s.maxmtu, 1400);
-        // Fix → Steady (try_fix_mtu), then steady probe → Revalidate{1}.
-        assert_eq!(s.phase, PmtuPhase::Revalidate { misses: 1 });
+        // Fix → Steady; the emitted revalidation probe is committed
+        // separately only after local UDP submission succeeds.
+        assert_eq!(s.phase, PmtuPhase::Steady);
+        assert!(out.contains(&PmtuAction::SendProbe {
+            len: 1400,
+            counts_miss: true,
+        }));
         assert!(out.contains(&PmtuAction::LogFixed {
             mtu: 1400,
             probes: 20
@@ -686,10 +726,18 @@ mod tests {
         assert_eq!(
             out,
             vec![
-                PmtuAction::SendProbe { len: 1400 },
-                PmtuAction::SendProbe { len: 1401 },
+                PmtuAction::SendProbe {
+                    len: 1400,
+                    counts_miss: true,
+                },
+                PmtuAction::SendProbe {
+                    len: 1401,
+                    counts_miss: false,
+                },
             ]
         );
+        assert_eq!(s.phase, PmtuPhase::Steady);
+        s.on_counted_probe_sent();
         assert_eq!(s.phase, PmtuPhase::Revalidate { misses: 1 });
     }
 
@@ -702,7 +750,36 @@ mod tests {
         s.minmtu = MTU - 1;
         s.phase = PmtuPhase::Steady;
         let out = s.tick(now + Duration::from_secs(61), Duration::from_secs(60));
-        assert_eq!(out, vec![PmtuAction::SendProbe { len: MTU - 1 }]);
+        assert_eq!(
+            out,
+            vec![PmtuAction::SendProbe {
+                len: MTU - 1,
+                counts_miss: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn failed_revalidation_submissions_do_not_count() {
+        let now = t0();
+        let mut s = PmtuState::new(now, MTU);
+        s.mtu = 1400;
+        s.minmtu = 1400;
+        s.maxmtu = 1400;
+        s.phase = PmtuPhase::Steady;
+        let pi = Duration::from_secs(60);
+
+        for second in [61, 122, 183] {
+            let out = s.tick(now + Duration::from_secs(second), pi);
+            assert!(matches!(
+                out.first(),
+                Some(PmtuAction::SendProbe {
+                    len: 1400,
+                    counts_miss: true
+                })
+            ));
+            assert_eq!(s.phase, PmtuPhase::Steady);
+        }
     }
 
     #[test]
@@ -716,10 +793,16 @@ mod tests {
         s.udp_confirmed = true;
         let pi = Duration::from_secs(60);
         s.tick(now + Duration::from_secs(61), pi);
+        assert_eq!(s.phase, PmtuPhase::Steady);
+        s.on_counted_probe_sent();
         assert_eq!(s.phase, PmtuPhase::Revalidate { misses: 1 });
         s.tick(now + Duration::from_secs(62), pi);
+        assert_eq!(s.phase, PmtuPhase::Revalidate { misses: 1 });
+        s.on_counted_probe_sent();
         assert_eq!(s.phase, PmtuPhase::Revalidate { misses: 2 });
         s.tick(now + Duration::from_secs(63), pi);
+        assert_eq!(s.phase, PmtuPhase::Revalidate { misses: 2 });
+        s.on_counted_probe_sent();
         assert_eq!(s.phase, PmtuPhase::Lost);
         // Lost → reset
         let out = s.tick(now + Duration::from_secs(64), pi);
@@ -785,6 +868,26 @@ mod tests {
         // Not confirmed.
         s.udp_confirmed = false;
         assert!(!s.udp_timed_out(now + Duration::from_secs(31), to));
+    }
+
+    #[test]
+    fn udp_probe_attempt_tracks_submission_separately() {
+        let now = t0();
+        let interval = Duration::from_secs(2);
+        let mut s = PmtuState::new(now, MTU);
+
+        let attempted_at = now + interval;
+        s.on_udp_probe_attempt(attempted_at, false);
+        assert!(!s.ping_sent);
+        assert_eq!(s.udp_probe_attempted_at, attempted_at);
+        assert_eq!(s.udp_ping_sent, now);
+        assert!(!s.udp_probe_due(attempted_at, interval));
+        assert!(s.udp_probe_due(attempted_at + interval, interval));
+
+        let sent_at = attempted_at + interval;
+        s.on_udp_probe_attempt(sent_at, true);
+        assert!(s.ping_sent);
+        assert_eq!(s.udp_ping_sent, sent_at);
     }
 
     // on_meta_ack.

--- a/crates/tincd/src/pmtu.rs
+++ b/crates/tincd/src/pmtu.rs
@@ -99,8 +99,8 @@ pub(crate) struct PmtuState {
     /// A keepalive probe is outstanding — next reply is the RTT
     /// measurement.
     pub ping_sent: bool,
-    /// Last local probe attempt, including failed submissions. Kept
-    /// separate from `udp_ping_sent`, which timestamps actual sends.
+    /// Last local probe attempt, including failed submissions
+    /// (`udp_ping_sent` timestamps actual sends).
     pub udp_probe_attempted_at: Instant,
     pub udp_ping_sent: Instant,
     /// Last time a probe **reply** arrived. Diagnostic only —
@@ -117,8 +117,8 @@ pub(crate) struct PmtuState {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PmtuAction {
     /// Send a UDP probe. `len` already clamped to `>= MIN_PROBE_SIZE`.
-    /// `counts_miss` marks the known-good `maxmtu` revalidation probe;
-    /// its successful submission advances the miss state separately.
+    /// `counts_miss`: a `maxmtu` revalidation probe whose successful
+    /// submission must be committed via `on_counted_probe_sent`.
     SendProbe { len: u16, counts_miss: bool },
 
     /// Log "Fixing MTU of %s to %d after %d probes". `probes` = how
@@ -292,9 +292,9 @@ impl PmtuState {
         out
     }
 
-    /// Commit one unanswered known-`maxmtu` probe after the UDP
-    /// datagram was accepted by the local socket. Failed submissions
-    /// leave the phase unchanged and are retried at normal cadence.
+    /// Commit one unanswered `maxmtu` probe after the local socket
+    /// accepted the datagram. Failed submissions leave the phase
+    /// unchanged.
     pub(crate) const fn on_counted_probe_sent(&mut self) {
         self.phase = match self.phase {
             PmtuPhase::Steady => PmtuPhase::Revalidate { misses: 1 },

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {

--- a/nix/nixos-test-dht.nix
+++ b/nix/nixos-test-dht.nix
@@ -185,6 +185,12 @@ let
           secure_mode=no
         '';
       };
+      # On slow (aarch64) boots miniupnpd can win the race against
+      # eth2's address assignment and die at startup. Retry instead.
+      systemd.services.miniupnpd.serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 1;
+      };
     };
 in
 testers.runNixOSTest {

--- a/nix/nixos-test-tincr.nix
+++ b/nix/nixos-test-tincr.nix
@@ -57,7 +57,10 @@ let
       networking.useDHCP = false;
       networking.firewall.enable = false;
 
-      environment.systemPackages = [ pkgs.dig ];
+      environment.systemPackages = [
+        pkgs.dig
+        tincd
+      ];
     };
 in
 testers.runNixOSTest {

--- a/nix/nixos-test-tincr.nix
+++ b/nix/nixos-test-tincr.nix
@@ -111,16 +111,18 @@ testers.runNixOSTest {
 
         alpha.wait_until_succeeds("ping -c1 -W2 10.21.0.2", timeout=30)
         beta.succeed("ping -c1 -W2 10.21.0.1")
+        # The UDP-confirmed bit needs a probe round trip, so poll.
         for m, peer in ((alpha, "beta"), (beta, "alpha")):
-            row = m.wait_until_succeeds(
-                "tinc --pidfile=/run/tincr/mesh.pid -n mesh dump nodes "
-                f"| grep '^{peer} '",
-                timeout=30,
-            )
-            match = re.search(r"status ([0-9a-f]+)", row)
-            assert match is not None, row
-            status = int(match.group(1), 16)
-            assert status & 0x80, row
+
+            def udp_confirmed(_: bool, m=m, peer=peer) -> bool:
+                row = m.succeed(
+                    "tinc --pidfile=/run/tincr/mesh.pid -n mesh dump nodes "
+                    f"| grep '^{peer} ' || true"
+                )
+                match = re.search(r"status ([0-9a-f]+)", row)
+                return match is not None and int(match.group(1), 16) & 0x80 != 0
+
+            retry(udp_confirmed, timeout_seconds=30)
 
     with subtest("DNS stub answers via systemd-resolved per-link routing"):
         for m in (alpha, beta):

--- a/nix/nixos-test-tincr.nix
+++ b/nix/nixos-test-tincr.nix
@@ -114,7 +114,9 @@ testers.runNixOSTest {
                 f"| grep '^{peer} '",
                 timeout=30,
             )
-            status = int(re.search(r"status ([0-9a-f]+)", row).group(1), 16)
+            match = re.search(r"status ([0-9a-f]+)", row)
+            assert match is not None, row
+            status = int(match.group(1), 16)
             assert status & 0x80, row
 
     with subtest("DNS stub answers via systemd-resolved per-link routing"):

--- a/nix/tincd.nix
+++ b/nix/tincd.nix
@@ -41,6 +41,8 @@ let
     # netns tests need bwrap+userns the sandbox lacks. The dev shell
     # runs the full suite; this is the deployment artifact.
     doCheck = false;
+    # Loopback-socket tests need this under the darwin sandbox.
+    __darwinAllowLocalNetworking = true;
   }
   // lib.optionalAttrs baselineCpu {
     # Env RUSTFLAGS replaces .cargo/config.toml's target.* rustflags

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,8 +1,12 @@
+{ pkgs, ... }:
 {
   projectRootFile = "flake.nix";
   programs = {
     rustfmt.enable = true;
+    # Rust port: unlike the GHC-based nixfmt it also evaluates on
+    # platforms without a Haskell toolchain (riscv64).
     nixfmt.enable = true;
+    nixfmt.package = pkgs.nixfmt-rs;
     # The C side stays under astyle (upstream's choice); don't
     # fight it from here.
   };


### PR DESCRIPTION
Darwin UDP egress could accept fragmented PMTU probes, silently drop unsent `sendmsg_x` batch tails, and count local socket failures as remote path loss. This change disables IPv4 and IPv6 fragmentation on macOS UDP sockets, replays only unaccepted batch tails through bounded per-packet fallback for UDP and utun, and advances PMTU revalidation only after successful UDP submission. deterministic tests cover socket-option readback, partial and zero-progress batch submissions, PMTU success and failure sequences, and the privileged real-utun cases remain root-gated.