### PR TITLE
Android: cross-compile tincd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.2+3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +983,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/tinc-crypto/Cargo.toml
+++ b/crates/tinc-crypto/Cargo.toml
@@ -19,6 +19,9 @@ kem.workspace = true
 rand_core.workspace = true
 getrandom.workspace = true
 
+[target.'cfg(target_os = "android")'.dependencies]
+openssl-sys = { workspace = true, features = ["vendored"] }
+
 [dev-dependencies]
 hex.workspace = true
 serde.workspace = true

--- a/crates/tinc-device/src/fd.rs
+++ b/crates/tinc-device/src/fd.rs
@@ -119,9 +119,9 @@ fn recv_one_fd(stream: &impl AsRawFd) -> io::Result<OwnedFd> {
     // and our cmsgbuf was sized for one). `MSG_OOB`/`MSG_ERRQUEUE`
     // can't happen on a Unix socket; checked to match C, zero cost.
     // `MSG_ERRQUEUE` is Linux-only.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     let bad = MsgFlags::MSG_CTRUNC | MsgFlags::MSG_OOB | MsgFlags::MSG_ERRQUEUE;
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     let bad = MsgFlags::MSG_CTRUNC | MsgFlags::MSG_OOB;
     if msg.flags.intersects(bad) {
         return Err(io::Error::new(
@@ -179,15 +179,18 @@ fn recv_one_fd(stream: &impl AsRawFd) -> io::Result<OwnedFd> {
 fn connect_unix(path: &Path) -> io::Result<UnixStream> {
     let bytes = path.as_os_str().as_encoded_bytes();
     if matches!(bytes.first(), Some(b'@')) {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // Abstract namespace: std adds the leading NUL, so strip `@`.
+            #[cfg(target_os = "android")]
+            use std::os::android::net::SocketAddrExt;
+            #[cfg(target_os = "linux")]
             use std::os::linux::net::SocketAddrExt;
             use std::os::unix::net::SocketAddr;
             let addr = SocketAddr::from_abstract_name(&bytes[1..])?;
             return UnixStream::connect_addr(&addr);
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         return Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "abstract Unix sockets ('@' prefix) are Linux-only",

--- a/crates/tinc-device/src/lib.rs
+++ b/crates/tinc-device/src/lib.rs
@@ -308,9 +308,9 @@ pub(crate) fn write_fd(fd: std::os::fd::BorrowedFd<'_>, buf: &[u8]) -> io::Resul
 
 // Linux TUN/TAP — `linux/device.c` (225 LOC)
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use linux::Tun;
 
 // fd — `fd_device.c` (Android backend).
@@ -322,9 +322,9 @@ pub use fd::{FdSource, FdTun};
 
 // raw — `raw_socket_device.c` (PF_PACKET backend). Linux-only.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod raw;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use raw::RawSocket;
 
 // bsd — `bsd/device.c` (three backends in one file). `cfg(unix)`

--- a/crates/tinc-device/src/linux.rs
+++ b/crates/tinc-device/src/linux.rs
@@ -339,7 +339,7 @@ fn ifreq_with_name(ifr_name: [libc::c_char; libc::IFNAMSIZ]) -> libc::ifreq {
 /// `TUNSETIFF` and `SIOCGIFHWADDR` both go through here so the
 /// unsafe surface is one audited block, not one per ioctl.
 #[allow(unsafe_code)]
-fn ioctl_ifreq(fd: BorrowedFd<'_>, req: libc::c_ulong, ifr: &mut libc::ifreq) -> io::Result<()> {
+fn ioctl_ifreq(fd: BorrowedFd<'_>, req: libc::Ioctl, ifr: &mut libc::ifreq) -> io::Result<()> {
     // SAFETY:
     //   - `fd` borrows an open fd; lifetime tied to the owning
     //     `File`, so it cannot be closed underneath us.
@@ -440,7 +440,7 @@ fn tunsetiff(
 /// dereference). Unlike `TUNSETIFF`, the encoding is honest.
 ///
 /// Not in the `libc` crate. Kernel ABI; can't change.
-const TUNSETOFFLOAD: libc::c_ulong = 0x4004_54d0;
+const TUNSETOFFLOAD: libc::Ioctl = 0x4004_54d0;
 
 /// `TUN_F_*` flags for `TUNSETOFFLOAD`. `if_tun.h:88-90`.
 /// `TUN_F_CSUM` is required for `TUN_F_TSO*` (`tun.c:2850`: TSO
@@ -488,7 +488,7 @@ fn siocgifhwaddr(fd: BorrowedFd<'_>) -> io::Result<Mac> {
 
     // Kernel reads NOTHING (TUN/TAP fd path; see above), WRITES
     // `ifr_ifru.ifru_hwaddr` (a `sockaddr`, 16 bytes at offset 16).
-    ioctl_ifreq(fd, libc::SIOCGIFHWADDR, &mut ifr)?;
+    ioctl_ifreq(fd, libc::SIOCGIFHWADDR as libc::Ioctl, &mut ifr)?;
 
     // `sockaddr.sa_data` is `[c_char; 14]`. First 6 bytes are the
     // MAC (ETH_ALEN=6).

--- a/crates/tincd/src/daemon/net.rs
+++ b/crates/tincd/src/daemon/net.rs
@@ -2,7 +2,7 @@ pub(super) use super::ListenerSlot;
 
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::sys::socket::MultiHeaders;
 use nix::sys::socket::SockaddrStorage;
 
@@ -33,7 +33,7 @@ pub(crate) struct UdpRxBatch {
     /// `mem::take`-cheap (one ptr, not 128KB).
     bufs: Box<[[u8; UDP_RX_BUFSZ]; UDP_RX_BATCH]>,
     /// nix's `mmsghdr` + `sockaddr_storage` arrays. Linux only.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     headers: MultiHeaders<SockaddrStorage>,
     /// Darwin `recvmsg_x` scratch. See [`macos_rx`].
     #[cfg(target_os = "macos")]
@@ -55,7 +55,7 @@ impl UdpRxBatch {
             .expect("vec![_; 64].into_boxed_slice() has length 64");
         Self {
             bufs,
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             headers: MultiHeaders::preallocate(UDP_RX_BATCH, None),
             #[cfg(target_os = "macos")]
             x: macos_rx::Scratch::new(),

--- a/crates/tincd/src/daemon/net/rx.rs
+++ b/crates/tincd/src/daemon/net/rx.rs
@@ -2,7 +2,7 @@ use super::super::Daemon;
 use super::{UDP_RX_BATCH, UDP_RX_BUFSZ, UdpRxBatch, ss_to_std};
 
 use std::io;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::io::IoSliceMut;
 use std::net::SocketAddr;
 use std::os::fd::AsRawFd;
@@ -19,7 +19,7 @@ use tinc_crypto::os_rng;
 use tinc_device::{Device, GroBucket};
 
 use nix::errno::Errno;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::sys::socket::{MsgFlags, recvmmsg};
 
 /// Cap on inbound pre-auth meta conns. `Tarpit` is per-IP; a
@@ -164,7 +164,7 @@ impl Daemon {
     /// `batch` borrow doesn't overlap `&mut self` at the call site.
     /// Phase 1 of UDP receive: syscall + extract (len, peer) per message.
     /// Linux: one recvmmsg(64). macOS: recvfrom loop.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn udp_recv_phase1(
         fd: std::os::fd::RawFd,
         batch: &mut UdpRxBatch,
@@ -202,7 +202,7 @@ impl Daemon {
     /// Phase 1, non-Linux: `recvmsg_x` on macOS (one syscall for up
     /// to `UDP_RX_BATCH` datagrams), `recvfrom` loop everywhere else
     /// and as the macOS `ENOSYS` fallback.
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     fn udp_recv_phase1(
         fd: std::os::fd::RawFd,
         batch: &mut UdpRxBatch,

--- a/crates/tincd/src/daemon/setup.rs
+++ b/crates/tincd/src/daemon/setup.rs
@@ -10,7 +10,10 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::os::fd::AsFd;
 #[cfg(unix)]
 use std::os::fd::{FromRawFd, OwnedFd};
+#[cfg(unix)]
+use std::os::unix::io::RawFd;
 use std::path::Path;
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use crate::event::{EventLoop, Io, SelfPipe, TimerId, Timers};
@@ -23,7 +26,7 @@ use tinc_proto::Subnet;
 use crate::compress;
 use crate::control::{ControlSocket, generate_cookie, write_pidfile};
 use crate::dispatch::myself_options_from_config;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
 use crate::egress::Portable;
 use crate::egress::UdpEgress;
 use crate::icmp;
@@ -161,7 +164,10 @@ fn expand_name(name: &str) -> Result<String, String> {
 /// `shards > 1` on a Linux multi-queue TUN).
 type ShardTuns = Vec<Box<dyn Device + Send>>;
 
-#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+#[cfg_attr(
+    not(any(target_os = "linux", target_os = "android")),
+    allow(unused_variables)
+)]
 fn open_device(
     config: &tinc_conf::Config,
     shards: usize,
@@ -188,38 +194,35 @@ fn open_device(
         Some("dummy") => Box::new(tinc_device::Dummy),
         #[cfg(unix)]
         Some("fd") => {
-            // The fd comes from `Device = N` (inherited fd) or
-            // `--device-fd N`. The integration test creates a
-            // socketpair, writes one end's fd into `Device = N`,
-            // and pumps IP packets through it. `FdTun` reads at
-            // `+14` (raw IP, no tun_pi prefix) and synthesizes
-            // the ethertype - the framing `route()` expects.
+            // `Device` = fd number, or socket path (`@` =
+            // abstract) for SCM_RIGHTS handover.
             let dev_str = config
                 .lookup("Device")
                 .next()
                 .map(tinc_conf::Entry::get_str)
-                .ok_or_else(|| SetupError::Config("DeviceType=fd requires Device = <fd>".into()))?;
-            let raw: std::os::unix::io::RawFd = dev_str
-                .parse()
-                .map_err(|_| SetupError::Config(format!("Device = {dev_str} is not a valid fd")))?;
-            // Negative fd numbers don't exist; reject before the
-            // unsafe wrap.
-            if raw < 0 {
-                return Err(SetupError::Config(format!(
-                    "Device = {raw}: inherited fd is negative"
-                )));
-            }
-            // SAFETY: the parent process dup2'd a tun fd to this
-            // number before exec; it is open and exclusively ours.
-            // Wrap NOW so any later `?` in setup closes it on drop
-            // rather than leaking the bare int.
-            #[allow(unsafe_code)]
-            let fd = unsafe { OwnedFd::from_raw_fd(raw) };
-            let tun = tinc_device::FdTun::open(tinc_device::FdSource::Inherited(fd))
-                .map_err(|e| SetupError::io(format!("open inherited device fd {raw}"), e))?;
+                .ok_or_else(|| {
+                    SetupError::Config("DeviceType=fd requires Device = <fd or socket path>".into())
+                })?;
+            let tun = if let Ok(raw) = dev_str.parse::<RawFd>() {
+                if raw < 0 {
+                    return Err(SetupError::Config(format!(
+                        "Device = {raw}: inherited fd is negative"
+                    )));
+                }
+                // SAFETY: the parent dup2'd an open tun fd to this
+                // number before exec. Wrapping now means later `?`
+                // closes it instead of leaking the bare int.
+                #[allow(unsafe_code)]
+                let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+                tinc_device::FdTun::open(tinc_device::FdSource::Inherited(fd))
+                    .map_err(|e| SetupError::io(format!("open inherited device fd {raw}"), e))?
+            } else {
+                tinc_device::FdTun::open(tinc_device::FdSource::UnixSocket(PathBuf::from(dev_str)))
+                    .map_err(|e| SetupError::io(format!("receive device fd from {dev_str}"), e))?
+            };
             Box::new(tun)
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         Some("tun") => {
             // Real kernel TUN via `/dev/net/tun` + TUNSETIFF.
             // Needs `CAP_NET_ADMIN`; the netns harness grants it
@@ -262,7 +265,7 @@ fn open_device(
                 .map_err(|e| SetupError::io("open TUN device /dev/net/tun", e))?;
             Box::new(tun)
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         Some("tap") => {
             // TODO: auto-derive tap when Mode != router and
             // DeviceType is unset. We only handle the explicit
@@ -351,7 +354,7 @@ fn register_listeners(
         // sends on the dup. Same file description → same bound
         // addr, same TOS (the daemon's `set_udp_tos` sets it on
         // the listener fd).
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let egress: Box<dyn UdpEgress> = Box::new(
             crate::egress::linux::Fast::new(&l.udp)
                 .map_err(|e| SetupError::io("dup UDP socket for egress", e))?,
@@ -361,7 +364,7 @@ fn register_listeners(
             crate::egress::macos::Fast::new(&l.udp)
                 .map_err(|e| SetupError::io("dup UDP socket for egress", e))?,
         );
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         let egress: Box<dyn UdpEgress> = Box::new(
             Portable::new(&l.udp).map_err(|e| SetupError::io("dup UDP socket for egress", e))?,
         );
@@ -656,6 +659,7 @@ impl Daemon {
         // device
         let (device, shard_tuns) = open_device(&config, n_shards, settings.shards.is_some())?;
         // open_device may have fallen back to a single queue.
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
         let n_shards = if shard_tuns.is_empty() {
             1
         } else {
@@ -1192,6 +1196,14 @@ impl Daemon {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+    #[cfg(unix)]
+    use std::io::IoSlice;
+    #[cfg(unix)]
+    use std::os::fd::AsRawFd;
+    #[cfg(unix)]
+    use std::os::unix::net::UnixListener;
 
     /// Construct a Config from `key = value` lines. Test-only.
     fn cfg_from(lines: &[&str]) -> tinc_conf::Config {
@@ -1224,6 +1236,59 @@ mod tests {
         assert_eq!(a.get("mail").unwrap(), "bob");
         assert!(!a.contains_key("bob"));
         assert_eq!(a.len(), 3);
+    }
+
+    /// Serve one fd via `SCM_RIGHTS`, like the app after `establish()`.
+    #[cfg(unix)]
+    fn serve_fd_once(listener: UnixListener) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let (_keep, give) = nix::unistd::pipe().unwrap();
+            let iov = [IoSlice::new(b"X")];
+            let fds = [give.as_raw_fd()];
+            let cmsg = ControlMessage::ScmRights(&fds);
+            sendmsg::<()>(stream.as_raw_fd(), &iov, &[cmsg], MsgFlags::empty(), None).unwrap();
+        })
+    }
+
+    /// `Device = /path`: receive the tun fd over the socket.
+    #[test]
+    #[cfg(unix)]
+    fn device_fd_from_unix_socket_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tun.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let srv = serve_fd_once(listener);
+
+        let cfg = cfg_from(&["DeviceType = fd", &format!("Device = {}", path.display())]);
+        let (dev, shard_tuns) = open_device(&cfg, 1, false).unwrap();
+        assert_eq!(dev.mode(), tinc_device::Mode::Tun);
+        assert!(shard_tuns.is_empty());
+        srv.join().unwrap();
+    }
+
+    /// `Device = @name`: abstract-namespace variant.
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn device_fd_from_abstract_socket() {
+        use std::os::linux::net::SocketAddrExt;
+        let name = format!("tincr-test-{}", std::process::id());
+        let addr = std::os::unix::net::SocketAddr::from_abstract_name(name.as_bytes()).unwrap();
+        let listener = UnixListener::bind_addr(&addr).unwrap();
+        let srv = serve_fd_once(listener);
+
+        let cfg = cfg_from(&["DeviceType = fd", &format!("Device = @{name}")]);
+        let (dev, _) = open_device(&cfg, 1, false).unwrap();
+        assert_eq!(dev.mode(), tinc_device::Mode::Tun);
+        srv.join().unwrap();
+    }
+
+    /// Non-numeric `Device` that isn't a live socket fails.
+    #[test]
+    #[cfg(unix)]
+    fn device_fd_missing_socket_fails() {
+        let cfg = cfg_from(&["DeviceType = fd", "Device = /nonexistent/tun.sock"]);
+        assert!(open_device(&cfg, 1, false).is_err());
     }
 
     /// `build_listeners` no-config default = `open_listeners`.

--- a/crates/tincd/src/daemon/tx_control.rs
+++ b/crates/tincd/src/daemon/tx_control.rs
@@ -5,7 +5,7 @@ use super::{ConnId, Daemon, PKT_PROBE, TimerWhat, parse_subnets_from_config};
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::AsRawFd;
 use std::time::{Duration, Instant};
 
@@ -24,7 +24,7 @@ use tinc_crypto::os_rng;
 use tinc_proto::AddrStr;
 use tinc_proto::msg::{MtuInfo, UdpInfo};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::sys::socket::{
     AddressFamily, SockFlag, SockType, SockaddrStorage, connect, getsockopt, socket, sockopt,
 };
@@ -41,7 +41,7 @@ use nix::sys::socket::{
 /// that window is stuck at MSS 536.
 ///
 /// Falls back to `MTU` on every error.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn choose_initial_maxmtu(_peer: SocketAddr) -> u16 {
     // macOS has no IP_MTU sockopt to query the kernel's PMTU cache.
     // Fall back to default MTU; the PMTU probing loop in pmtu.rs will
@@ -50,7 +50,7 @@ fn choose_initial_maxmtu(_peer: SocketAddr) -> u16 {
     MTU
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn choose_initial_maxmtu(peer: SocketAddr) -> u16 {
     // Ephemeral DGRAM socket, only for the kernel's route+PMTU
     // lookup. Never sends.

--- a/crates/tincd/src/egress.rs
+++ b/crates/tincd/src/egress.rs
@@ -19,7 +19,7 @@ use std::io;
 
 use socket2::{SockAddr, Socket};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) mod linux;
 #[cfg(target_os = "macos")]
 pub(crate) mod macos;
@@ -314,7 +314,7 @@ impl TxBatch {
 /// `send_to` — `Portable::send_batch` with `count=1` IS one `sendto`.
 // Linux uses `linux::Fast`; `Portable` stays for the wire-equivalence
 // test in `egress/linux.rs` and as the non-Linux backend.
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), allow(dead_code))]
 pub(crate) struct Portable {
     /// `dup(2)` of `Listener.udp`. Same file description, so
     /// `SO_BINDTODEVICE`/`IP_TOS`/etc. set on the listener apply
@@ -323,7 +323,7 @@ pub(crate) struct Portable {
     sock: Socket,
 }
 
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), allow(dead_code))]
 impl Portable {
     /// Build from a dup of the listener's UDP socket.
     ///

--- a/crates/tincd/src/event/io/mod.rs
+++ b/crates/tincd/src/event/io/mod.rs
@@ -20,9 +20,9 @@ use std::io;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod epoll;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use epoll::{
     Poller, RawEvent, add, create, del, empty_event, ev_readable, ev_token, ev_writable, modify,
     wait,
@@ -500,7 +500,7 @@ mod tests {
     /// the same fd twice (epoll rejects). kqueue silently replaces
     /// with `EV_ADD`, so this test is Linux-only.
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn add_failure_frees_slot() {
         let mut ev = EventLoop::new().unwrap();
         let (rd, _wr) = mkpipe();

--- a/crates/tincd/src/listen.rs
+++ b/crates/tincd/src/listen.rs
@@ -104,7 +104,7 @@ where
 }
 
 /// Test-only readback for `IP_MTU_DISCOVER`/`IPV6_MTU_DISCOVER`.
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(all(test, any(target_os = "linux", target_os = "android")))]
 pub(crate) fn get_int_sockopt(
     fd: BorrowedFd<'_>,
     level: libc::c_int,
@@ -246,7 +246,8 @@ fn apply_common_sockopts(
         log::warn!(target: "tincd::net", "IPV6_V6ONLY{label}: {e}");
     }
 
-    // SO_MARK: Linux netfilter mark for policy routing. 0 = unset = skip.
+    // SO_MARK: Linux netfilter mark for policy routing. 0 = unset =
+    // skip. Android blocks it via SELinux, so it stays linux-only.
     #[cfg(target_os = "linux")]
     if opts.fwmark != 0
         && let Err(e) = setsockopt(&s.as_fd(), sockopt::Mark, &opts.fwmark)
@@ -437,7 +438,7 @@ fn setup_udp(addr: &SockAddr, opts: &SockOpts, v6only: bool) -> io::Result<Socke
 
     s.set_nonblocking(true)?;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     if opts.shard_group {
         s.set_reuse_port(true)?;
     }
@@ -637,7 +638,7 @@ fn open_one(
 ///
 /// # Errors
 /// Any bind/setsockopt failure. Caller falls back to `Shards = 1`.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn open_udp_siblings(
     l: &Listener,
     opts: &SockOpts,

--- a/crates/tincd/src/main.rs
+++ b/crates/tincd/src/main.rs
@@ -481,10 +481,10 @@ fn drop_privs(
         let cuser = CString::new(user).map_err(|_| "username contains NUL".to_string())?;
         tincd::initgroups(&cuser, pw.gid)
             .map_err(|e| format!("System call `initgroups' failed: {e}"))?;
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         nix::unistd::setresgid(pw.gid, pw.gid, pw.gid)
             .map_err(|e| format!("System call `setresgid' failed: {e}"))?;
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         nix::unistd::setgid(pw.gid).map_err(|e| format!("System call `setgid' failed: {e}"))?;
 
         Some((pw.uid, pw.gid))
@@ -511,7 +511,7 @@ fn drop_privs(
 
     // setresuid last (real/effective/saved); after this we can't undo.
     if let Some((uid, gid)) = uid_gid {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             nix::unistd::setresuid(uid, uid, uid)
                 .map_err(|e| format!("System call `setresuid' failed: {e}"))?;
@@ -526,7 +526,7 @@ fn drop_privs(
                 return Err(format!("setresgid did not stick: got {rg:?}, want {gid}"));
             }
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let _ = gid; // gid already set via setgid above
             nix::unistd::setuid(uid).map_err(|e| format!("System call `setuid' failed: {e}"))?;
@@ -858,9 +858,9 @@ fn main() -> ExitCode {
     };
     let sandbox_paths = sandbox::Paths {
         confbase: args.confbase.clone(),
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         device: Some("/dev/net/tun".into()),
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         device: None,
         logfile: args.logfile.clone(),
         pidfile: args.pidfile.clone(),

--- a/crates/tincd/src/outgoing.rs
+++ b/crates/tincd/src/outgoing.rs
@@ -733,7 +733,7 @@ mod tests {
     /// but on a bare dial socket (no bind/connect). Proves the
     /// outgoing path actually applies the sockopt.
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn dial_sockopts_bind_to_interface_lo() {
         use nix::sys::socket::{getsockopt, sockopt};
         let sock = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
@@ -766,7 +766,7 @@ mod tests {
     /// `CAP_NET_ADMIN`; skip otherwise (matches `listen.rs::
     /// open_fwmark_set`).
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn dial_sockopts_fwmark() {
         use nix::sys::socket::{getsockopt, sockopt};
         let euid = nix::unistd::geteuid();

--- a/crates/tincd/src/platform.rs
+++ b/crates/tincd/src/platform.rs
@@ -8,7 +8,7 @@
 use std::ffi::CStr;
 use std::io;
 use std::os::fd::AsFd;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::AsRawFd;
 
 use nix::sys::socket::SockFlag;
@@ -20,11 +20,11 @@ use socket2::Socket;
 #[inline]
 #[must_use]
 pub(crate) fn sock_cloexec_flag() -> SockFlag {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         SockFlag::SOCK_CLOEXEC
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         SockFlag::empty()
     }
@@ -33,24 +33,24 @@ pub(crate) fn sock_cloexec_flag() -> SockFlag {
 /// Set `SO_NOSIGPIPE` on macOS so `send()` returns `EPIPE` instead
 /// of raising `SIGPIPE` on broken TCP connections. Linux uses
 /// `MSG_NOSIGNAL` per-send instead.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub(crate) fn set_nosigpipe(fd: impl AsFd) {
     let _ = socket2::SockRef::from(&fd).set_nosigpipe(true);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[inline]
 pub(crate) fn set_nosigpipe(_fd: impl AsFd) {}
 
 /// Set `FD_CLOEXEC` via `fcntl`. Use after socket/socketpair on
 /// platforms without `SOCK_CLOEXEC`.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub(crate) fn set_cloexec(fd: impl AsFd) {
     use nix::fcntl::{FcntlArg, FdFlag, fcntl};
     let _ = fcntl(fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC));
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[inline]
 pub(crate) fn set_cloexec(_fd: impl AsFd) {}
 
@@ -59,11 +59,11 @@ pub(crate) fn set_cloexec(_fd: impl AsFd) {}
 #[inline]
 #[must_use]
 pub(crate) fn msg_nosignal() -> nix::sys::socket::MsgFlags {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         nix::sys::socket::MsgFlags::MSG_NOSIGNAL
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         nix::sys::socket::MsgFlags::empty()
     }
@@ -77,7 +77,7 @@ pub(crate) fn msg_nosignal() -> nix::sys::socket::MsgFlags {
 ///
 /// # Errors
 /// `last_os_error()` from `setsockopt(2)`.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_int_sockopt(
     fd: impl AsFd,
     level: libc::c_int,
@@ -133,7 +133,7 @@ pub(crate) fn set_udp_tos(fd: impl AsFd, is_ipv6: bool, prio: u8) {
 ///
 /// # Errors
 /// `setsockopt(SO_BINDTODEVICE)` failure.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn bind_to_interface(s: &Socket, iface: &str) -> io::Result<()> {
     use nix::sys::socket::{setsockopt, sockopt};
     let name = std::ffi::OsString::from(iface);
@@ -143,7 +143,7 @@ pub(crate) fn bind_to_interface(s: &Socket, iface: &str) -> io::Result<()> {
 
 /// # Errors
 /// Unknown interface or `setsockopt` failure.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub(crate) fn bind_to_interface(s: &Socket, iface: &str) -> io::Result<()> {
     use std::num::NonZeroU32;
     // macOS equivalent of SO_BINDTODEVICE: IP_BOUND_IF /
@@ -163,7 +163,7 @@ pub(crate) fn bind_to_interface(s: &Socket, iface: &str) -> io::Result<()> {
 /// Disable IP fragmentation so PMTU probes reach the underlay as one
 /// datagram. Best-effort: warn only. Linux has no `DONTFRAG` toggle.
 /// `PMTUDISC_DO` sets DF and fails oversized sends with `EMSGSIZE`.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn set_udp_dontfrag(s: &Socket, ipv6: bool) {
     let (label, result) = if ipv6 {
         (
@@ -192,7 +192,7 @@ pub(crate) fn set_udp_dontfrag(s: &Socket, ipv6: bool) {
 }
 
 /// macOS: `IP{,V6}_DONTFRAG` sets DF without the kernel PMTU cache.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub(crate) fn set_udp_dontfrag(s: &Socket, ipv6: bool) {
     use nix::sys::socket::{setsockopt, sockopt};
     let (label, result) = if ipv6 {
@@ -221,11 +221,11 @@ pub(crate) fn set_udp_dontfrag(s: &Socket, ipv6: bool) {
 /// # Errors
 /// fork/setsid failure, formatted for the CLI.
 pub fn daemonize() -> Result<(), String> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         nix::unistd::daemon(true, false).map_err(|e| format!("Couldn't detach from terminal: {e}"))
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         // nix::unistd::daemon is Linux-only in nix 0.29.
         // Use libc::daemon directly.

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1787208815,
+        "narHash": "sha256-SiyWmwDoDF2jCEpEW887qxaUazaQrVQs+QXq2bvgm+0=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "428f69c19e46334bed722164c5125b62d3722723",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1787360063,
@@ -34,8 +55,26 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787106123,
+        "narHash": "sha256-Usi0dFNYgdN5gXYDjLLGCYYkzW7Xl9uBhwGD5OkuWoM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "32a3346dff5b26e16227affd5af933e15ebc598b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane.url = "github:ipetkov/crane";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -16,6 +20,7 @@
       nixpkgs,
       treefmt-nix,
       crane,
+      fenix,
     }:
     let
       systems = [
@@ -25,11 +30,22 @@
         "riscv64-linux"
       ];
       eachSystem = f: nixpkgs.lib.genAttrs systems (system: f system nixpkgs.legacyPackages.${system});
+      # androidenv needs the unfree SDK license accepted.
+      androidPkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            android_sdk.accept_license = true;
+          };
+        };
       treefmt = eachSystem (_: pkgs: treefmt-nix.lib.evalModule pkgs ./nix/treefmt.nix);
     in
     {
       packages = eachSystem (
-        system: pkgs: {
+        system: pkgs:
+        {
           default = self.packages.${system}.tincd;
           kat-vectors = pkgs.callPackage ./nix/kat-vectors.nix { };
           kat-graph = pkgs.callPackage ./nix/kat-graph.nix { };
@@ -45,12 +61,28 @@
           # Pre-Haswell x86_64 (no AVX2). See baselineCpu in tincd.nix.
           tincd-compat = self.packages.${system}.tincd.override { baselineCpu = true; };
         }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          tincd-android =
+            let
+              pkgs' = androidPkgsFor system;
+            in
+            pkgs'.callPackage ./nix/tincd-android.nix {
+              craneLib = crane.mkLib pkgs';
+              fenix = fenix.packages.${system};
+            };
+        }
       );
 
       devShells = eachSystem (
-        system: pkgs: {
+        system: pkgs:
+        {
           default = pkgs.callPackage ./nix/devshell.nix {
             inherit (self.packages.${system}) tincd-c sptps-test-c;
+          };
+        }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          android = (androidPkgsFor system).callPackage ./nix/devshell-android.nix {
+            fenix = fenix.packages.${system};
           };
         }
       );

--- a/nix/android-env.nix
+++ b/nix/android-env.nix
@@ -1,0 +1,32 @@
+# Pinned NDK and per-target cargo/cc env, shared by the android
+# devshell and the tincd-android package.
+{ lib, androidenv }:
+let
+  composition = androidenv.composeAndroidPackages {
+    includeNDK = true;
+    # r27 LTS, pinned so the toolchain doesn't move on nixpkgs bumps.
+    ndkVersion = "27.2.12479018";
+    platformVersions = [ "35" ];
+  };
+  ndkRoot = "${composition.androidsdk}/libexec/android-sdk/ndk-bundle";
+  # NDK ships linux-x86_64 host prebuilts only.
+  ndkBin = "${ndkRoot}/toolchains/llvm/prebuilt/linux-x86_64/bin";
+  api = "24"; # min API, encoded in the clang wrapper name
+in
+{
+  inherit ndkRoot;
+  envFor =
+    target:
+    let
+      u = lib.replaceStrings [ "-" ] [ "_" ] target;
+      cc = "${ndkBin}/${target}${api}-clang";
+    in
+    {
+      "CARGO_TARGET_${lib.toUpper u}_LINKER" = cc;
+      # Google Play requires 16 KB page support for targetSdk 35.
+      "CARGO_TARGET_${lib.toUpper u}_RUSTFLAGS" = "-C link-arg=-Wl,-z,max-page-size=16384";
+      "CC_${u}" = cc;
+      "AR_${u}" = "${ndkBin}/llvm-ar";
+      "RANLIB_${u}" = "${ndkBin}/llvm-ranlib";
+    };
+}

--- a/nix/devshell-android.nix
+++ b/nix/devshell-android.nix
@@ -1,0 +1,40 @@
+# Android cross-compile shell.
+{
+  mkShell,
+  lib,
+  androidenv,
+  fenix,
+  cargo-ndk,
+  perl,
+  gnumake,
+}:
+let
+  android = import ./android-env.nix { inherit lib androidenv; };
+  targets = [
+    "aarch64-linux-android"
+    "x86_64-linux-android"
+  ];
+  toolchain = fenix.combine (
+    [
+      fenix.stable.cargo
+      fenix.stable.rustc
+      fenix.stable.clippy
+      fenix.stable.rustfmt
+    ]
+    ++ map (t: fenix.targets.${t}.stable.rust-std) targets
+  );
+in
+mkShell (
+  {
+    packages = [
+      toolchain
+      cargo-ndk
+      perl # for openssl-src
+      gnumake
+    ];
+    ANDROID_NDK_ROOT = android.ndkRoot;
+    ANDROID_NDK_HOME = android.ndkRoot;
+    meta.platforms = lib.platforms.linux;
+  }
+  // lib.mergeAttrsList (map android.envFor targets)
+)

--- a/nix/tincd-android.nix
+++ b/nix/tincd-android.nix
@@ -1,0 +1,38 @@
+# Android cross build of tincd. CI builds this instead of a cargo job.
+{
+  craneLib,
+  lib,
+  fenix,
+  androidenv,
+  perl,
+  target ? "aarch64-linux-android",
+}:
+let
+  android = import ./android-env.nix { inherit lib androidenv; };
+  toolchain = fenix.combine [
+    fenix.stable.cargo
+    fenix.stable.rustc
+    fenix.targets.${target}.stable.rust-std
+  ];
+  craneLib' = craneLib.overrideToolchain toolchain;
+  common = {
+    src = lib.fileset.toSource {
+      root = ../.;
+      fileset = lib.fileset.unions [
+        ../Cargo.toml
+        ../Cargo.lock
+        ../crates
+      ];
+    };
+    pname = "tincd-android";
+    version = "0.1.0";
+    strictDeps = true;
+    cargoExtraArgs = "-p tincd";
+    nativeBuildInputs = [ perl ]; # openssl-src
+    doCheck = false;
+    CARGO_BUILD_TARGET = target;
+  }
+  // android.envFor target;
+  cargoArtifacts = craneLib'.buildDepsOnly common;
+in
+craneLib'.buildPackage (common // { inherit cargoArtifacts; })


### PR DESCRIPTION
Cross-compiles tincd for Android (NDK r27, vendored OpenSSL), `Device = <socket path>` for fd handover, nix packages `tincd-android{,-x86_64}`, deduped toolchain env.

Part 1/3 of the Android port stack.