### PR TITLE
tinc join: add --identity-only

### DIFF
--- a/crates/tinc-tools/src/bin/tinc.rs
+++ b/crates/tinc-tools/src/bin/tinc.rs
@@ -51,7 +51,7 @@ use std::io;
 use std::io::{IsTerminal, Read};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tinc_tools::cmd::{self, CmdError};
+use tinc_tools::cmd::{self, CmdError, join};
 use tinc_tools::names::{Paths, PathsInput};
 
 /// How a command consumes its positionals. `main` does the arity
@@ -196,7 +196,7 @@ const COMMANDS: &[CmdEntry] = &[
         name: "join",
         needs_daemon: false,
         run: Run::Any(cmd_join),
-        help: "join INVITATION        Join a VPN using an invitation.",
+        help: "join [URL]             Join a VPN using an invitation.\n    --identity-only[=FILE] - only register a key, write it to FILE or stdout",
     },
     // daemon RPC
     // `start`/`restart`: not really daemon-RPC (they *spawn* the
@@ -721,10 +721,26 @@ fn cmd_help(_: &Paths, _: &Globals, _: &[String]) -> Result<(), CmdError> {
 
 /// URL on argv or piped on stdin (no tty prompt — same "no prompts"
 /// deviation as elsewhere). `--force` propagates to `finalize_join`'s
-/// `VAR_SAFE` override.
+/// `VAR_SAFE` override. `--identity-only[=FILE]` registers a key with the
+/// inviter and writes nothing but that key, to FILE or stdout.
 fn cmd_join(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError> {
+    let mut mode = join::Mode::Full {
+        paths,
+        force: g.force,
+    };
+    let mut rest = Vec::new();
+    for arg in args {
+        match arg.strip_prefix("--identity-only") {
+            Some("") => mode = join::Mode::IdentityOnly(None),
+            Some(f) if f.starts_with('=') => {
+                mode = join::Mode::IdentityOnly(Some(PathBuf::from(&f[1..])));
+            }
+            _ => rest.push(arg.as_str()),
+        }
+    }
+
     let url_buf;
-    let url: &str = match args {
+    let url: &str = match rest.as_slice() {
         [u] => u,
         [] => {
             let mut buf = String::new();
@@ -737,7 +753,7 @@ fn cmd_join(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError>
         _ => return Err(CmdError::TooManyArgs),
     };
 
-    cmd::join::join(url, paths, g.force)
+    join::join(url, &mode)
 }
 
 fn cmd_verify(paths: &Paths, _: &Globals, args: &[String]) -> Result<(), CmdError> {

--- a/crates/tinc-tools/src/cmd/join.rs
+++ b/crates/tinc-tools/src/cmd/join.rs
@@ -65,7 +65,7 @@ mod wire;
 #[cfg(all(test, unix))]
 mod tests;
 
-pub use finalize::finalize_join;
+pub use finalize::{finalize_identity, finalize_join};
 pub use url::{ParsedUrl, parse_url};
 
 #[cfg_attr(not(test), expect(unused_imports))]
@@ -73,6 +73,7 @@ pub(crate) use server_stub::server_receive_cookie;
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use tinc_crypto::b64;
@@ -121,34 +122,59 @@ pub struct JoinResult {
     pub hosts_written: Vec<String>,
 }
 
-/// `tinc join URL`. `paths` should be a fresh confbase; checked up front (and
-/// again in `finalize_join`) so we fail before connecting and burning the
-/// single-use cookie. One sequence sharing sockets, SPTPS pump and blob state.
+/// What to do with the invitation once the daemon hands it over.
+pub enum Mode<'a> {
+    /// Write tinc.conf, hosts/*, key and tinc-up into `paths`.
+    Full { paths: &'a Paths, force: bool },
+    /// Register a fresh key with the inviter and keep only that key, in
+    /// the given file or on stdout. For hosts whose config is deployed by
+    /// other means.
+    IdentityOnly(Option<PathBuf>),
+}
+
+impl Mode<'_> {
+    /// Checked before connecting: the daemon burns the cookie on receipt,
+    /// so "file exists" must not be discovered afterwards.
+    fn preflight(&self) -> Result<(), CmdError> {
+        let existing = match self {
+            Mode::Full { paths, .. } => {
+                if let Some(confdir) = &paths.confdir {
+                    makedir(confdir, 0o755)?;
+                }
+                makedir(&paths.confbase, 0o755)?;
+                paths.tinc_conf()
+            }
+            Mode::IdentityOnly(Some(key)) => key.clone(),
+            Mode::IdentityOnly(None) => return Ok(()),
+        };
+        if existing.exists() {
+            return Err(CmdError::BadInput(format!(
+                "{} already exists!",
+                existing.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn finalize(&self, data: &[u8]) -> Result<JoinResult, CmdError> {
+        match self {
+            Mode::Full { paths, force } => finalize_join(data, paths, *force),
+            Mode::IdentityOnly(key) => finalize_identity(data, key.as_deref()),
+        }
+    }
+}
+
+/// `tinc join URL`. In `Full` mode `paths` should be a fresh confbase,
+/// checked up front so we fail before connecting and burning the single-use
+/// cookie. One sequence sharing sockets, SPTPS pump and blob state.
 ///
 /// # Errors
 /// `BadInput` (bad URL, wrong greeting, `key_hash` mismatch, blob parse) or
 /// `Io`.
-pub fn join(url: &str, paths: &Paths, force: bool) -> Result<(), CmdError> {
-    // Parse URL
+pub fn join(url: &str, mode: &Mode<'_>) -> Result<(), CmdError> {
     let parsed =
         parse_url(url).ok_or_else(|| CmdError::BadInput("Invalid invitation URL.".into()))?;
-
-    // Preflight before connecting: the daemon renames the cookie to .used on
-    // receipt, so failing on "tinc.conf exists" afterwards would burn the
-    // invitation. Confbase (and confdir) are created here for the access check;
-    // `finalize_join` adds hosts/cache.
-    if let Some(confdir) = &paths.confdir {
-        makedir(confdir, 0o755)?;
-    }
-    makedir(&paths.confbase, 0o755)?;
-
-    let tinc_conf = paths.tinc_conf();
-    if tinc_conf.exists() {
-        return Err(CmdError::BadInput(format!(
-            "Configuration file {} already exists!",
-            tinc_conf.display()
-        )));
-    }
+    mode.preflight()?;
 
     // Generate throwaway key
     // This key is only for the SPTPS handshake; it's not the node's
@@ -271,7 +297,7 @@ pub fn join(url: &str, paths: &Paths, force: bool) -> Result<(), CmdError> {
                         // case 1: finalize returns the pubkey; the send
                         // happens here.
                         1 => {
-                            let r = finalize_join(&data, paths, force)?;
+                            let r = mode.finalize(&data)?;
                             pubkey_to_send = Some(r.pubkey_b64);
                             joined_name = Some(r.name);
                         }
@@ -394,7 +420,9 @@ pub fn join(url: &str, paths: &Paths, force: bool) -> Result<(), CmdError> {
         ));
     }
 
-    eprintln!("Configuration stored in: {}", paths.confbase.display());
+    if let Mode::Full { paths, .. } = mode {
+        eprintln!("Configuration stored in: {}", paths.confbase.display());
+    }
     if let Some(name) = joined_name {
         eprintln!("Joined as: {name}");
     }

--- a/crates/tinc-tools/src/cmd/join/finalize.rs
+++ b/crates/tinc-tools/src/cmd/join/finalize.rs
@@ -5,8 +5,8 @@
 //! needs to go back over the wire.
 
 use std::fs;
-use std::io::Write;
-use std::path::PathBuf;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 use tinc_conf::vars::{self, VarFlags};
 use tinc_crypto::b64;
@@ -105,6 +105,29 @@ pub fn finalize_join(data: &[u8], paths: &Paths, force: bool) -> Result<JoinResu
         }
     }
     r
+}
+
+/// `--identity-only` counterpart of [`finalize_join`]: validate the blob
+/// header, generate the node key, write it to `key` (or stdout) and drop
+/// everything else the inviter sent.
+///
+/// # Errors
+/// Blob has no valid `Name`, or the key cannot be written.
+pub fn finalize_identity(data: &[u8], key: Option<&Path>) -> Result<JoinResult, CmdError> {
+    let data = str::from_utf8(data)
+        .map_err(|_| CmdError::BadInput("Invitation data is not valid UTF-8".into()))?;
+    let name = parse_blob_header(&mut data.lines())?;
+    let sk = keypair::generate();
+    match key {
+        Some(path) => cmd::write_private_key(path, &sk, OpenKind::CreateExcl)?,
+        None => tinc_conf::pem::write_pem(io::stdout().lock(), keypair::TY_PRIVATE, &sk.to_blob())
+            .map_err(io_err("<stdout>"))?,
+    }
+    Ok(JoinResult {
+        name,
+        pubkey_b64: b64::encode(sk.public_key()),
+        hosts_written: Vec::new(),
+    })
 }
 
 fn finalize_join_inner(

--- a/crates/tinc-tools/src/cmd/join/tests.rs
+++ b/crates/tinc-tools/src/cmd/join/tests.rs
@@ -149,6 +149,34 @@ fn finalize_minimal_blob() {
     assert_eq!(b64::encode(sk.public_key()), r.pubkey_b64);
 }
 
+/// Identity-only: the key goes where asked, nothing lands in confbase.
+#[test]
+fn finalize_identity_writes_only_the_key() {
+    let cd = ConfDir::bare();
+    let key = cd.path().join("key.priv");
+    let blob = b"Name = bob\nMode = switch\n#-#\nName = alice\nAddress = x\n";
+    let r = finalize_identity(blob, Some(&key)).unwrap();
+    assert_eq!(r.name, "bob");
+    let sk = keypair::read_private(&key).unwrap();
+    assert_eq!(b64::encode(sk.public_key()), r.pubkey_b64);
+    assert_eq!(
+        fs::metadata(&key).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    assert!(!cd.paths().tinc_conf().exists());
+    assert_eq!(fs::read_dir(cd.paths().hosts_dir()).unwrap().count(), 0);
+    // A second run must not clobber an existing key.
+    assert!(finalize_identity(blob, Some(&key)).is_err());
+}
+
+#[test]
+fn finalize_identity_rejects_bad_blob() {
+    let cd = ConfDir::bare();
+    let key = cd.path().join("k");
+    assert!(finalize_identity(b"Mode = switch\n", Some(&key)).is_err());
+    assert!(!key.exists());
+}
+
 /// `VAR_SAFE` filter. `Mode` is SERVER|SAFE → tinc.conf.
 /// `Subnet` is HOST|MULTIPLE|SAFE → hosts/bob.
 /// `Device` is SERVER but not SAFE → dropped (without --force).

--- a/crates/tinc-tools/tests/tinc_cli/invite_join.rs
+++ b/crates/tinc-tools/tests/tinc_cli/invite_join.rs
@@ -88,3 +88,23 @@ fn join_with_existing_config_fails_before_connect() {
         .fails_with("already exists");
     assert!(!stderr.contains("connect"), "{stderr}");
 }
+
+/// `--identity-only` ignores an existing tinc.conf (the config is managed
+/// elsewhere) but refuses to clobber an existing key, again before
+/// connecting.
+#[test]
+fn join_identity_only_preflight() {
+    let url = format!("127.0.0.1:1/{}", "a".repeat(SLUG_LEN));
+    let conf = Conf::init("alice");
+    let stderr = conf
+        .tinc(&["join", "--identity-only", &url])
+        .fails_with("connect");
+    assert!(!stderr.contains("already exists"), "{stderr}");
+
+    let key = conf.dir().join("k");
+    fs::write(&key, "").unwrap();
+    let stderr = conf
+        .tinc(&["join", &format!("--identity-only={}", key.display()), &url])
+        .fails_with("already exists");
+    assert!(!stderr.contains("connect"), "{stderr}");
+}

--- a/crates/tincd/tests/two_daemons/reload.rs
+++ b/crates/tincd/tests/two_daemons/reload.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::thread;
 use tinc_crypto::invite::{build_slug, cookie_filename};
 use tinc_crypto::sign::SigningKey;
+use tinc_tools::cmd::join::Mode;
 use tinc_tools::names::{Paths, PathsInput};
 
 /// Rewrite `hosts/SELF` with `subnets` and SIGHUP. The sleep is for
@@ -85,6 +86,13 @@ fn invite_bob(alice: &Node) -> (String, PathBuf) {
     (url, invitation_file)
 }
 
+fn full(paths: &Paths) -> Mode<'_> {
+    Mode::Full {
+        paths,
+        force: false,
+    }
+}
+
 fn cli_paths(confbase: PathBuf) -> Paths {
     Paths::for_cli(&PathsInput {
         confbase: Some(confbase),
@@ -103,7 +111,7 @@ fn tinc_join_consumes_invitation() {
     let (url, invitation_file) = invite_bob(&alice);
     let paths_for = |dir: &str| cli_paths(tmp.path().join(dir));
 
-    if let Err(err) = tinc_tools::cmd::join::join(&url, &paths_for("bob"), false) {
+    if let Err(err) = tinc_tools::cmd::join::join(&url, &full(&paths_for("bob"))) {
         panic!("join: {err:?}\nalice:\n{}", alice.stop());
     }
     let bob_confbase = tmp.path().join("bob");
@@ -130,7 +138,7 @@ fn tinc_join_consumes_invitation() {
     assert!(!invitation_file.with_extension("used").exists());
 
     assert!(
-        tinc_tools::cmd::join::join(&url, &paths_for("bob2"), false).is_err(),
+        tinc_tools::cmd::join::join(&url, &full(&paths_for("bob2"))).is_err(),
         "invitation reused"
     );
 }
@@ -160,7 +168,7 @@ fn join_with_overlay_writes_there_and_peer_connects() {
     let (url, _) = invite_bob(&alice);
 
     let bob_confbase = tmp.path().join("bob");
-    if let Err(err) = tinc_tools::cmd::join::join(&url, &cli_paths(bob_confbase.clone()), false) {
+    if let Err(err) = tinc_tools::cmd::join::join(&url, &full(&cli_paths(bob_confbase.clone()))) {
         panic!("join: {err:?}\nalice:\n{}", alice.stop());
     }
     let overlay_bob = alice.confbase.join("hosts.local/bob");
@@ -184,6 +192,40 @@ fn join_with_overlay_writes_there_and_peer_connects() {
     );
     append("hosts/bob", "Port = 0\n");
     let mut bob = Node::new(tmp.path(), "bob", 0xBB);
+    bob.start();
+    alice.wait_for_peer("bob", true, Duration::from_secs(10));
+}
+
+/// `--identity-only`: bob's config is deployed out of band (here: written
+/// by the test), the join only registers a key with alice and hands bob
+/// the private half via `Ed25519PrivateKeyFile`.
+#[test]
+fn identity_only_join_registers_key_and_peer_connects() {
+    let tmp = tmp!("joinid");
+    let mut alice = Node::new(tmp.path(), "alice", 0xAA);
+    alice.write_config_multi(&[], &[]);
+    alice.start();
+    let (url, _) = invite_bob(&alice);
+
+    let key = tmp.path().join("vault/bob.priv");
+    fs::create_dir_all(key.parent().unwrap()).unwrap();
+    if let Err(err) = tinc_tools::cmd::join::join(&url, &Mode::IdentityOnly(Some(key.clone()))) {
+        panic!("join: {err:?}\nalice:\n{}", alice.stop());
+    }
+    assert!(key.exists());
+    assert!(
+        !tmp.path().join("bob").exists(),
+        "identity-only wrote a confbase"
+    );
+    let alice_hosts_bob = alice.confbase.join("hosts/bob");
+    assert!(wait_for_file(&alice_hosts_bob));
+
+    // The "deploy": bob's confbase from the registry, key from the vault.
+    let mut bob = Node::new(tmp.path(), "bob", 0xBB)
+        .with_conf(&format!("Ed25519PrivateKeyFile = {}\n", key.display()));
+    bob.write_config_multi(&[&alice], &[&alice]);
+    // Not the harness key: the one the join generated.
+    fs::remove_file(bob.confbase.join("ed25519_key.priv")).unwrap();
     bob.start();
     alice.wait_for_peer("bob", true, Duration::from_secs(10));
 }

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -90,7 +90,22 @@ services.tincr.networks = {
 
 Some things stay operator-driven rather than declared: private
 keys, peer invitations (`tinc -n <net> invite`), and joining
-(`tinc -n <net> join <url>`). Since `hosts/` lives in the store,
+(`tinc -n <net> join <url>`).
+
+To enrol a module-managed host through an invitation without it ever
+writing config, run the join where the secret is kept:
+
+```console
+$ tinc join --identity-only=./secrets/web1-tinc.priv <url>
+```
+
+This registers a new key with the inviting node (whose
+`invitation-accepted` hook can commit `hosts/web1` to the registry)
+and leaves only the private key behind. Encrypt it with sops/agenix,
+set `ed25519PrivateKeyFile` to the decrypted path, deploy. Without
+`=FILE` the PEM goes to stdout, for piping into a secrets tool.
+
+Since `hosts/` lives in the store,
 the module sets `HostsOverlayDirectory = /var/lib/tincr/<net>/hosts`:
 nodes that accept an invitation are written there and stay valid
 across deploys until they are added to `hosts` proper.

--- a/man/tinc.8
+++ b/man/tinc.8
@@ -148,8 +148,22 @@ followed by
 Generate an invitation URL for
 .Ar NODE
 and print it to stdout.
-.It Cm join Op Ar URL
+.It Cm join Oo Fl -identity-only Ns Oo = Ns Ar FILE Oc Oc Op Ar URL
 Join a network using an invitation URL (read from stdin if omitted).
+With
+.Fl -identity-only
+no configuration is written.
+A fresh key is registered with the inviter and its private half goes to
+.Ar FILE ,
+or stdout, for hosts whose
+.Pa tinc.conf
+and
+.Pa hosts/
+are deployed by other means.
+Run it where the secret should live, for example inside a secrets
+generator on the admin machine, and point
+.Va Ed25519PrivateKeyFile
+at the result.
 .El
 .Ss Daemon control
 .Bl -tag -width Ds


### PR DESCRIPTION
Stacked on #66.

Hosts whose config is deployed (NixOS module, registry checkout) could not use invitations because `tinc join` writes a whole confbase. `--identity-only` runs the same exchange, so the inviter records the key and its `invitation-accepted` hook fires, but keeps only the private key, in `FILE` (`--identity-only=FILE`) or on stdout. Run inside a sops/clan-vars generator the key is born in the vault. `docs/NIXOS.md` shows the flow with `ed25519PrivateKeyFile`.

Tests: finalizer unit tests, CLI preflight (existing tinc.conf is fine, existing key file is refused before connecting), and a two-daemon test where bob joins identity-only, gets a harness-written confbase plus `Ed25519PrivateKeyFile`, and authenticates to alice with the registered key.
