### PR TITLE
android: bind the tun fd socket before starting tincd

### DIFF
--- a/android/app/src/main/kotlin/io/thalheim/tincr/TunFdServer.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TunFdServer.kt
@@ -4,12 +4,12 @@ import android.net.LocalServerSocket
 import java.io.FileDescriptor
 
 // Sends the tun fd via SCM_RIGHTS to tincd (Device = @NAME).
-class TunFdServer(private val name: String, private val fd: FileDescriptor) {
+class TunFdServer(name: String, private val fd: FileDescriptor) {
+    private val server = LocalServerSocket(name)
+
     fun serveOnce() {
-        val server = LocalServerSocket(name)
         try {
-            val sock = server.accept()
-            sock.use {
+            server.accept().use {
                 it.setFileDescriptorsForSend(arrayOf(fd))
                 it.outputStream.write(1)
                 it.outputStream.flush()


### PR DESCRIPTION
tincd was spawned before `@tincr-tun` was bound (the bind happened inside `serveOnce()`), so on a fast run it got ECONNREFUSED fetching the device fd. Seen as an `android-mesh` failure on #67. Bind in the constructor instead.