### PR TITLE
tinc invite --replace

### DIFF
--- a/crates/tinc-conf/src/hostdirs.rs
+++ b/crates/tinc-conf/src/hostdirs.rs
@@ -1,9 +1,10 @@
 //! `hosts/` plus an optional `HostsOverlayDirectory`.
 //!
 //! On managed systems `hosts/` is deployed read-only from a registry.
-//! Accepted invitations are written to the overlay instead, so a deploy
-//! never clobbers them. Lookups try `hosts/` first and fall back to the
-//! overlay, which means the registry copy wins once a node lands there.
+//! Runtime writes (accepted invitations, replaced keys) go to the overlay
+//! so a deploy never clobbers them. Like `/etc` over `/usr/lib`, the
+//! overlay wins on lookup; an entry there is pruned once the registry
+//! copy has caught up.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -39,19 +40,29 @@ impl HostDirs {
         Self::new(confbase, overlay)
     }
 
-    /// Path to read `name` from. Prefers `hosts/`, then the overlay. When
+    /// Path to read `name` from. Prefers the overlay, then `hosts/`. When
     /// neither has it, returns the `hosts/` path so error messages point
     /// there.
     #[must_use]
     pub fn file(&self, name: &str) -> PathBuf {
-        let p = self.primary.join(name);
-        if present(&p) {
-            return p;
-        }
         match &self.overlay {
             Some(o) if present(&o.join(name)) => o.join(name),
-            _ => p,
+            _ => self.primary.join(name),
         }
+    }
+
+    /// Names present in both dirs: the overlay copy masks the deployed one.
+    #[must_use]
+    pub fn overridden(&self) -> Vec<String> {
+        let Some(o) = &self.overlay else {
+            return Vec::new();
+        };
+        let mut names = BTreeSet::new();
+        let _ = collect(o, &mut names);
+        names
+            .into_iter()
+            .filter(|n| present(&self.primary.join(n)))
+            .collect()
     }
 
     /// Any directory entry for `name` in either dir, dangling symlinks
@@ -120,8 +131,8 @@ mod tests {
     use super::*;
     use std::os::unix::fs::symlink;
 
-    /// A dangling symlink in `hosts/` still occupies the name. Falling
-    /// through to the overlay would let an invitee claim it.
+    /// A dangling symlink still occupies the name, so an invitee cannot
+    /// claim it.
     #[test]
     fn dangling_symlink_occupies_name() {
         let tmp = tempfile::tempdir().unwrap();
@@ -129,11 +140,12 @@ mod tests {
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
         fs::create_dir_all(&ov).unwrap();
         symlink("/nonexistent", tmp.path().join("hosts/bob")).unwrap();
-        fs::write(ov.join("bob"), "").unwrap();
-        let d = HostDirs::new(tmp.path(), Some(ov));
+        symlink("/nonexistent", ov.join("carol")).unwrap();
+        let d = HostDirs::new(tmp.path(), Some(ov.clone()));
         assert!(d.exists("bob"));
-        assert_eq!(d.file("bob"), tmp.path().join("hosts/bob"));
-        assert!(!d.exists("carol"));
+        assert!(d.exists("carol"));
+        assert_eq!(d.file("carol"), ov.join("carol"));
+        assert!(!d.exists("dave"));
     }
 
     /// A missing overlay is normal before the first join. An unreadable one
@@ -163,17 +175,19 @@ mod tests {
     }
 
     #[test]
-    fn primary_shadows_overlay() {
+    fn overlay_overrides_primary() {
         let tmp = tempfile::tempdir().unwrap();
         let ov = tmp.path().join("hosts.local");
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
         fs::create_dir_all(&ov).unwrap();
         let d = HostDirs::new(tmp.path(), Some(ov.clone()));
 
-        fs::write(ov.join("bob"), "").unwrap();
-        assert_eq!(d.file("bob"), ov.join("bob"));
         fs::write(tmp.path().join("hosts/bob"), "").unwrap();
         assert_eq!(d.file("bob"), tmp.path().join("hosts/bob"));
+        assert!(d.overridden().is_empty());
+        fs::write(ov.join("bob"), "").unwrap();
+        assert_eq!(d.file("bob"), ov.join("bob"));
+        assert_eq!(d.overridden(), ["bob"]);
 
         assert_eq!(d.file("nobody"), tmp.path().join("hosts/nobody"));
         assert_eq!(d.write_path("carol"), ov.join("carol"));

--- a/crates/tinc-crypto/src/invite.rs
+++ b/crates/tinc-crypto/src/invite.rs
@@ -70,6 +70,21 @@ pub const SLUG_PART_LEN: usize = 24;
 /// Full slug length: `b64(key_hash) || b64(cookie)`.
 pub const SLUG_LEN: usize = 2 * SLUG_PART_LEN;
 
+/// First line of a replace-invitation: `#replace <old-b64-pubkey>`. tincr
+/// only; the daemon strips it before sending, `tinc join` never sees it.
+pub const REPLACE_MARKER: &str = "#replace ";
+
+/// Split an optional replace marker off an invitation file. Returns the
+/// pinned old key (still b64) and the remainder starting at `Name =`.
+#[must_use]
+pub fn strip_replace_marker(contents: &[u8]) -> (Option<&[u8]>, &[u8]) {
+    let Some(rest) = contents.strip_prefix(REPLACE_MARKER.as_bytes()) else {
+        return (None, contents);
+    };
+    let nl = rest.iter().position(|&b| b == b'\n').unwrap_or(rest.len());
+    (Some(&rest[..nl]), rest.get(nl + 1..).unwrap_or_default())
+}
+
 // Compile-time witness that 18 → 24 is the encoding length we claimed.
 // b64 length for n bytes (no padding) is `(n*4).div_ceil(3)`. 18*4/3 = 24
 // exactly, no ceil needed. If someone bumps COOKIE_LEN this fires.
@@ -196,6 +211,16 @@ pub fn parse_slug(slug: &str) -> Option<([u8; COOKIE_LEN], [u8; COOKIE_LEN])> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replace_marker() {
+        assert_eq!(strip_replace_marker(b"Name = a\n"), (None, &b"Name = a\n"[..]));
+        assert_eq!(
+            strip_replace_marker(b"#replace abc\nName = a\n"),
+            (Some(&b"abc"[..]), &b"Name = a\n"[..])
+        );
+        assert_eq!(strip_replace_marker(b"#replace abc"), (Some(&b"abc"[..]), &b""[..]));
+    }
 
     /// `key_hash(pk) == fingerprint_hash(fingerprint(pk))`. The KAT
     /// proves `key_hash` matches C; this proves `fingerprint_hash`

--- a/crates/tinc-crypto/src/invite.rs
+++ b/crates/tinc-crypto/src/invite.rs
@@ -214,12 +214,18 @@ mod tests {
 
     #[test]
     fn replace_marker() {
-        assert_eq!(strip_replace_marker(b"Name = a\n"), (None, &b"Name = a\n"[..]));
+        assert_eq!(
+            strip_replace_marker(b"Name = a\n"),
+            (None, &b"Name = a\n"[..])
+        );
         assert_eq!(
             strip_replace_marker(b"#replace abc\nName = a\n"),
             (Some(&b"abc"[..]), &b"Name = a\n"[..])
         );
-        assert_eq!(strip_replace_marker(b"#replace abc"), (Some(&b"abc"[..]), &b""[..]));
+        assert_eq!(
+            strip_replace_marker(b"#replace abc"),
+            (Some(&b"abc"[..]), &b""[..])
+        );
     }
 
     /// `key_hash(pk) == fingerprint_hash(fingerprint(pk))`. The KAT

--- a/crates/tinc-tools/src/bin/tinc.rs
+++ b/crates/tinc-tools/src/bin/tinc.rs
@@ -190,7 +190,7 @@ const COMMANDS: &[CmdEntry] = &[
         // unredeemable until manual restart.
         needs_daemon: true,
         run: Run::Any(cmd_invite),
-        help: "invite NODE            Generate an invitation for NODE.",
+        help: "invite [--replace] NODE  Generate an invitation for NODE.\n    --replace - let a new device take over NODE's name, replacing its key",
     },
     CmdEntry {
         name: "join",
@@ -481,6 +481,10 @@ fn cmd_fsck(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError>
 /// `tinc invite alice | mail alice@example` works). Warnings to
 /// stderr.
 fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError> {
+    let (replace, args) = match args.split_first() {
+        Some((a, rest)) if a == "--replace" => (true, rest),
+        _ => (false, args),
+    };
     let [invitee] = args else {
         return Err(if args.is_empty() {
             CmdError::MissingArg("node name")
@@ -489,7 +493,13 @@ fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdErro
         });
     };
 
-    let r = cmd::invite::invite(paths, g.netname.as_deref(), invitee, SystemTime::now())?;
+    let r = cmd::invite::invite(
+        paths,
+        g.netname.as_deref(),
+        invitee,
+        replace,
+        SystemTime::now(),
+    )?;
 
     if r.key_is_new {
         // The daemon loads `invitations/ed25519_key.priv` at startup;

--- a/crates/tinc-tools/src/cmd/dump.rs
+++ b/crates/tinc-tools/src/cmd/dump.rs
@@ -34,7 +34,7 @@ use crate::names::{Paths, check_id};
 // Re-exported so existing `cmd::dump::{NodeRow,…}` paths keep working.
 pub use crate::ctl::rows::{ConnRow, EdgeRow, NodeRow, StatusBit, SubnetRow, strip_weight};
 use std::io::ErrorKind;
-use tinc_crypto::invite::SLUG_PART_LEN;
+use tinc_crypto::invite::{REPLACE_MARKER, SLUG_PART_LEN};
 
 /// Which `dump` sub-verb.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,9 +177,16 @@ pub fn dump_invitations(paths: &Paths) -> Result<Vec<InviteRow>, CmdError> {
         let Ok(file) = fs::File::open(&path) else {
             continue;
         };
+        let mut rd = BufReader::new(file);
         let mut first = String::new();
-        if BufReader::new(file).read_line(&mut first).is_err() || first.is_empty() {
+        if rd.read_line(&mut first).is_err() || first.is_empty() {
             continue;
+        }
+        if first.starts_with(REPLACE_MARKER) {
+            first.clear();
+            if rd.read_line(&mut first).is_err() {
+                continue;
+            }
         }
 
         // Route through the canonical split_kv so a hand-edited `Name=bob`

--- a/crates/tinc-tools/src/cmd/dump/tests.rs
+++ b/crates/tinc-tools/src/cmd/dump/tests.rs
@@ -495,6 +495,7 @@ fn inv_valid_table() {
         // Same tokenizer as tinc.conf — a hand-edited `Name=bob` must
         // list even though invite always writes the spaced form.
         ("no-space `=`",                "Name=bob\n"),
+        ("replace marker",              "#replace abc\nName = bob\n"),
     ];
     for (label, content) in cases {
         let (d, paths) = setup_inv();
@@ -661,7 +662,7 @@ fn inv_roundtrip_with_invite() {
 
     // `now` is parameterized for sweep_expired tests; pass real time.
     let now = SystemTime::now();
-    let result = invite::invite(&paths, None, "bob", now).unwrap();
+    let result = invite::invite(&paths, None, "bob", false, now).unwrap();
     // Only the written file matters here, not the returned URL.
     let _ = result;
 

--- a/crates/tinc-tools/src/cmd/exchange.rs
+++ b/crates/tinc-tools/src/cmd/exchange.rs
@@ -374,7 +374,7 @@ mod tests {
     }
 
     /// Nodes the daemon accepted into `HostsOverlayDirectory` are peers
-    /// too. `hosts/` wins when both have the name.
+    /// too. The overlay wins when both have the name.
     #[test]
     fn export_all_includes_overlay() {
         let cd = setup("alice", "Subnet = 10.0.1.0/24\n")
@@ -384,7 +384,7 @@ mod tests {
         export_all(cd.paths(), &mut out).unwrap();
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("Name = bob\nSubnet = 10.0.2.0/24"), "{s}");
-        assert!(!s.contains("6.6.6.6"), "{s}");
+        assert!(!s.contains("10.0.1.0"), "{s}");
         assert_eq!(s.matches("Name = alice").count(), 1);
     }
 

--- a/crates/tinc-tools/src/cmd/invite.rs
+++ b/crates/tinc-tools/src/cmd/invite.rs
@@ -54,7 +54,8 @@ use std::time::{Duration, SystemTime};
 
 use rand_core::Rng;
 use tinc_conf::Config;
-use tinc_crypto::invite::{COOKIE_LEN, SLUG_PART_LEN, build_slug, cookie_filename};
+use tinc_crypto::invite::{COOKIE_LEN, REPLACE_MARKER, SLUG_PART_LEN, build_slug, cookie_filename};
+use tinc_crypto::b64;
 use tinc_crypto::os_rng;
 use tinc_crypto::sign::SigningKey;
 use zeroize::Zeroizing;
@@ -103,10 +104,9 @@ pub struct InviteResult {
     pub key_is_new: bool,
 }
 
-/// `tinc invite NODENAME`. `now` is injectable for tests; `netname` feeds the
-/// invitation's `NetName =` line (`Paths` only has the resolved confbase). One
-/// sequence of validate, mkdir, sweep, key, hash, file, url sharing local
-/// state.
+/// `tinc invite [--replace] NODENAME`. `now` is injectable for tests. With
+/// `replace`, NODENAME must exist and its current Ed25519 key is pinned in
+/// the invitation so the daemon swaps exactly that key at join time.
 ///
 /// # Errors
 /// `BadInput` (invalid or taken name, no `Address` configured) or `Io`.
@@ -114,6 +114,7 @@ pub fn invite(
     paths: &Paths,
     netname: Option<&str>,
     invitee: &str,
+    replace: bool,
     now: SystemTime,
 ) -> Result<InviteResult, CmdError> {
     if !check_id(invitee) {
@@ -125,13 +126,32 @@ pub fn invite(
     // Needed for the `ConnectTo` line and the host config dump.
     let myname = get_my_name(paths)?;
 
-    // Known in `hosts/` or the overlay. The daemon would refuse the join,
-    // so refuse to mint the URL.
-    if paths.host_dirs().exists(invitee) {
-        return Err(CmdError::BadInput(format!(
-            "A host config file for {invitee} already exists!"
-        )));
-    }
+    let hosts = paths.host_dirs();
+    let old_key = if replace {
+        if invitee == myname {
+            return Err(CmdError::BadInput("Cannot replace myself".into()));
+        }
+        if !hosts.exists(invitee) {
+            return Err(CmdError::BadInput(format!(
+                "No host config file for {invitee}, nothing to replace"
+            )));
+        }
+        let file = hosts.file(invitee);
+        let cfg = Config::read(&file).map_err(|e| CmdError::BadInput(e.to_string()))?;
+        let key = keypair::load_public_from_config(&cfg, &file).ok_or_else(|| {
+            CmdError::BadInput(format!("{} has no Ed25519 public key to replace", file.display()))
+        })?;
+        Some(b64::encode(&key))
+    } else {
+        // Known in `hosts/` or the overlay. The daemon would refuse the
+        // join, so refuse to mint the URL.
+        if hosts.exists(invitee) {
+            return Err(CmdError::BadInput(format!(
+                "A host config file for {invitee} already exists! (--replace issues a new key for it)"
+            )));
+        }
+        None
+    };
 
     // Get our address (for the URL host part) early, so a no-Address
     // failure happens before any files are created.
@@ -198,7 +218,10 @@ pub fn invite(
     // Write the invitation file, O_EXCL 0600 (an 18-byte random cookie can't
     // collide, so EEXIST is a real problem). Built as one string and written once:
     // testable builder, no partial writes.
-    let body = build_invitation_file(paths, netname, invitee, &myname, &address)?;
+    let mut body = build_invitation_file(paths, netname, invitee, &myname, &address)?;
+    if let Some(k) = &old_key {
+        body.insert_str(0, &format!("{REPLACE_MARKER}{k}\n"));
+    }
     write_invitation_file(&inv_path, &body)?;
 
     // Build the URL
@@ -206,7 +229,16 @@ pub fn invite(
     let slug = Zeroizing::new(build_slug(pubkey, &cookie));
     let url = Zeroizing::new(format!("{address}/{}", *slug));
 
-    if let Err(e) = run_created_hook(paths, netname, &myname, invitee, &inv_path, &url) {
+    let hook = run_created_hook(
+        paths,
+        netname,
+        &myname,
+        invitee,
+        old_key.as_deref(),
+        &inv_path,
+        &url,
+    );
+    if let Err(e) = hook {
         let _ = fs::remove_file(&inv_path);
         return Err(e);
     }
@@ -222,6 +254,7 @@ fn run_created_hook(
     netname: Option<&str>,
     myname: &str,
     invitee: &str,
+    old_key: Option<&str>,
     inv_path: &Path,
     url: &str,
 ) -> Result<(), CmdError> {
@@ -236,6 +269,9 @@ fn run_created_hook(
         .env("INVITATION_URL", url);
     if let Some(n) = netname {
         cmd.env("NETNAME", n);
+    }
+    if let Some(k) = old_key {
+        cmd.env("REPLACE", k);
     }
     let status = cmd.status().map_err(io_err(&script))?;
     if status.success() {
@@ -718,7 +754,7 @@ mod tests {
         let confbase = cd.confbase();
         init_with_address(&paths, "alice", "myhost.example");
 
-        let r = invite(&paths, Some("testnet"), "bob", SystemTime::now()).unwrap();
+        let r = invite(&paths, Some("testnet"), "bob", false, SystemTime::now()).unwrap();
 
         // Key was freshly generated (first invite).
         assert!(r.key_is_new);
@@ -806,15 +842,9 @@ mod tests {
         .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let r = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
 
-        let inv_dir = cd.confbase().join("invitations");
-        let file = fs::read_dir(&inv_dir)
-            .unwrap()
-            .map(|e| e.unwrap().path())
-            .find(|p| p.file_name().unwrap().len() == SLUG_PART_LEN)
-            .unwrap();
-        let body = fs::read_to_string(file).unwrap();
+        let body = only_invitation(&cd);
         assert!(
             body.ends_with(&format!(
                 "Subnet = 10.0.0.7\n# bob alice {}\n",
@@ -835,7 +865,7 @@ mod tests {
         fs::write(&script, "#!/bin/sh\nexit 3\n").unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let err = invite(&paths, None, "bob", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
         assert!(err.to_string().contains("invitation-created"), "{err}");
 
         let inv_dir = cd.confbase().join("invitations");
@@ -855,13 +885,13 @@ mod tests {
         init_with_address(&paths, "alice", "myhost");
 
         // First invite: creates key + invitation file for bob.
-        let r1 = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r1 = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
         assert!(r1.key_is_new);
 
         let key_path = paths.invitation_key();
         fs::write(&key_path, "garbage, not PEM\n").unwrap();
 
-        let err = invite(&paths, None, "carol", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "carol", false, SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -886,10 +916,10 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
 
-        let r1 = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r1 = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
         assert!(r1.key_is_new);
 
-        let r2 = invite(&paths, None, "carol", SystemTime::now()).unwrap();
+        let r2 = invite(&paths, None, "carol", false, SystemTime::now()).unwrap();
         assert!(!r2.key_is_new, "second invite should reuse key");
 
         // Same key → same key_hash in both URLs.
@@ -912,7 +942,7 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
         // hosts/alice exists (init created it). Inviting alice fails.
-        let err = invite(&paths, None, "alice", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "alice", false, SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -928,8 +958,60 @@ mod tests {
         init_with_address(&paths, "alice", "myhost");
         let cd = cd.with_overlay_host("bob", "");
         let paths = cd.paths().clone();
-        let err = invite(&paths, None, "bob", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
         assert!(matches!(err, CmdError::BadInput(m) if m.contains("already exists")));
+    }
+
+    fn only_invitation(cd: &ConfDir) -> String {
+        let inv_dir = cd.confbase().join("invitations");
+        let file = fs::read_dir(&inv_dir)
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .find(|p| p.file_name().unwrap().len() == SLUG_PART_LEN)
+            .unwrap();
+        fs::read_to_string(file).unwrap()
+    }
+
+    /// `--replace` pins the node's current key on the first line, hands it
+    /// to the hook as `REPLACE`, and leaves the rest of the file as for a
+    /// fresh invite.
+    #[test]
+    fn replace_pins_old_key() {
+        let cd = ConfDir::bare();
+        let paths = cd.paths().clone();
+        init_with_address(&paths, "alice", "myhost");
+        let old = b64::encode(&[7u8; 32]);
+        let cd = cd.with_overlay_host("bob", &format!("Subnet = 10.0.0.7\nEd25519PublicKey = {old}\n"));
+        let paths = cd.paths().clone();
+        let script = cd.confbase().join("invitation-created");
+        fs::write(&script, "#!/bin/sh\necho \"# $REPLACE\" >> \"$INVITATION_FILE\"\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+        invite(&paths, None, "bob", true, SystemTime::now()).unwrap();
+
+        let body = only_invitation(&cd);
+        assert!(
+            body.starts_with(&format!("{REPLACE_MARKER}{old}\nName = bob\n")),
+            "{body}"
+        );
+        assert!(body.ends_with(&format!("# {old}\n")), "{body}");
+    }
+
+    #[test]
+    fn replace_refusals() {
+        let cd = ConfDir::bare();
+        let paths = cd.paths().clone();
+        init_with_address(&paths, "alice", "myhost");
+        let cd = cd.with_overlay_host("rsa", "Subnet = 10.0.0.8\n");
+        let paths = cd.paths().clone();
+        for (who, want) in [
+            ("bob", "nothing to replace"),
+            ("alice", "myself"),
+            ("rsa", "no Ed25519 public key"),
+        ] {
+            let err = invite(&paths, None, who, true, SystemTime::now()).unwrap_err();
+            assert!(matches!(&err, CmdError::BadInput(m) if m.contains(want)), "{who}: {err}");
+        }
     }
 
     /// invite with no Address → clear error before any files created.
@@ -941,7 +1023,7 @@ mod tests {
         let confbase = cd.confbase();
         init::run(&paths, "alice").unwrap(); // no Address
 
-        let err = invite(&paths, None, "bob", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -961,7 +1043,7 @@ mod tests {
         let cd = ConfDir::bare();
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
-        let err = invite(&paths, None, "../etc", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "../etc", false, SystemTime::now()).unwrap_err();
         assert!(matches!(err, CmdError::BadInput(_)));
     }
 
@@ -984,7 +1066,7 @@ mod tests {
         writeln!(tc, "Device = /dev/net/tun").unwrap();
         drop(tc);
 
-        let r = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
         let slug = r.url.rsplit('/').next().unwrap();
         let (_, cookie) = tinc_crypto::invite::parse_slug(slug).unwrap();
         let sk = keypair::read_private(&paths.invitation_key()).unwrap();

--- a/crates/tinc-tools/src/cmd/invite.rs
+++ b/crates/tinc-tools/src/cmd/invite.rs
@@ -54,8 +54,8 @@ use std::time::{Duration, SystemTime};
 
 use rand_core::Rng;
 use tinc_conf::Config;
-use tinc_crypto::invite::{COOKIE_LEN, REPLACE_MARKER, SLUG_PART_LEN, build_slug, cookie_filename};
 use tinc_crypto::b64;
+use tinc_crypto::invite::{COOKIE_LEN, REPLACE_MARKER, SLUG_PART_LEN, build_slug, cookie_filename};
 use tinc_crypto::os_rng;
 use tinc_crypto::sign::SigningKey;
 use zeroize::Zeroizing;
@@ -139,7 +139,10 @@ pub fn invite(
         let file = hosts.file(invitee);
         let cfg = Config::read(&file).map_err(|e| CmdError::BadInput(e.to_string()))?;
         let key = keypair::load_public_from_config(&cfg, &file).ok_or_else(|| {
-            CmdError::BadInput(format!("{} has no Ed25519 public key to replace", file.display()))
+            CmdError::BadInput(format!(
+                "{} has no Ed25519 public key to replace",
+                file.display()
+            ))
         })?;
         Some(b64::encode(&key))
     } else {
@@ -981,10 +984,17 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
         let old = b64::encode(&[7u8; 32]);
-        let cd = cd.with_overlay_host("bob", &format!("Subnet = 10.0.0.7\nEd25519PublicKey = {old}\n"));
+        let cd = cd.with_overlay_host(
+            "bob",
+            &format!("Subnet = 10.0.0.7\nEd25519PublicKey = {old}\n"),
+        );
         let paths = cd.paths().clone();
         let script = cd.confbase().join("invitation-created");
-        fs::write(&script, "#!/bin/sh\necho \"# $REPLACE\" >> \"$INVITATION_FILE\"\n").unwrap();
+        fs::write(
+            &script,
+            "#!/bin/sh\necho \"# $REPLACE\" >> \"$INVITATION_FILE\"\n",
+        )
+        .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
         invite(&paths, None, "bob", true, SystemTime::now()).unwrap();
@@ -1010,7 +1020,10 @@ mod tests {
             ("rsa", "no Ed25519 public key"),
         ] {
             let err = invite(&paths, None, who, true, SystemTime::now()).unwrap_err();
-            assert!(matches!(&err, CmdError::BadInput(m) if m.contains(want)), "{who}: {err}");
+            assert!(
+                matches!(&err, CmdError::BadInput(m) if m.contains(want)),
+                "{who}: {err}"
+            );
         }
     }
 

--- a/crates/tinc-tools/src/cmd/join/tests.rs
+++ b/crates/tinc-tools/src/cmd/join/tests.rs
@@ -49,7 +49,7 @@ fn url_roundtrip_with_invite() {
     let inviter = ConfDir::init("alice").append_host("alice", "Address = vpn.example\n");
     let inviter = inviter.paths();
 
-    let r = invite::invite(inviter, None, "bob", SystemTime::now()).unwrap();
+    let r = invite::invite(inviter, None, "bob", false, SystemTime::now()).unwrap();
     let p = parse_url(&r.url).unwrap();
     assert_eq!(p.host, "vpn.example");
     assert_eq!(p.port, "655");
@@ -428,7 +428,7 @@ fn server_stub_recovers_file() {
     let cd = ConfDir::init("alice").append_host("alice", "Address = x\n");
     let p = cd.paths();
 
-    let r = invite::invite(p, None, "bob", SystemTime::now()).unwrap();
+    let r = invite::invite(p, None, "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&r.url).unwrap();
     let inv_key = keypair::read_private(&p.invitation_key()).unwrap();
 
@@ -454,7 +454,7 @@ fn server_stub_single_use() {
     let cd = ConfDir::init("alice").append_host("alice", "Address = x\n");
     let p = cd.paths();
 
-    let r = invite::invite(p, None, "bob", SystemTime::now()).unwrap();
+    let r = invite::invite(p, None, "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&r.url).unwrap();
     let inv_key = keypair::read_private(&p.invitation_key()).unwrap();
 
@@ -496,7 +496,7 @@ fn invite_join_roundtrip_in_process() {
         .append_conf("Mode = switch\n");
     let inviter = inviter_cd.paths();
 
-    let inv_result = invite::invite(inviter, Some("acme"), "bob", SystemTime::now()).unwrap();
+    let inv_result = invite::invite(inviter, Some("acme"), "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&inv_result.url).unwrap();
 
     // Load invitation key. Both the server stub and the joiner's

--- a/crates/tinc-tools/src/cmd/join/tests.rs
+++ b/crates/tinc-tools/src/cmd/join/tests.rs
@@ -496,7 +496,8 @@ fn invite_join_roundtrip_in_process() {
         .append_conf("Mode = switch\n");
     let inviter = inviter_cd.paths();
 
-    let inv_result = invite::invite(inviter, Some("acme"), "bob", false, SystemTime::now()).unwrap();
+    let inv_result =
+        invite::invite(inviter, Some("acme"), "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&inv_result.url).unwrap();
 
     // Load invitation key. Both the server stub and the joiner's

--- a/crates/tincd/src/daemon/metaconn.rs
+++ b/crates/tincd/src/daemon/metaconn.rs
@@ -15,6 +15,7 @@ use crate::dispatch::{
     record_body, send_ack,
 };
 use crate::invitation_serve::InvitePhase;
+use crate::keys;
 use crate::outgoing::ProxyConfig;
 use crate::script::ScriptEnv;
 use crate::tunnel::MTU;
@@ -926,7 +927,12 @@ impl Daemon {
                                 self.settings.invitation_lifetime,
                                 SystemTime::now(),
                             );
-                            let (contents, invited_name, used_path) = match result {
+                            let invitation_serve::Served {
+                                contents,
+                                name: invited_name,
+                                replace,
+                                used_path,
+                            } = match result {
                                 Ok(t) => t,
                                 Err(e) => {
                                     log::error!(target: "tincd::auth",
@@ -959,13 +965,14 @@ impl Daemon {
 
                             conn.invite = Some(InvitePhase::WaitingPubkey {
                                 name: invited_name.clone(),
+                                replace,
                             });
 
                             log::info!(target: "tincd::auth",
                                         "Invitation successfully sent to {invited_name} ({hostname})");
                         }
 
-                        (1, Some(InvitePhase::WaitingPubkey { name })) => {
+                        (1, Some(InvitePhase::WaitingPubkey { name, replace })) => {
                             // newline check happens inside finalize().
                             let Ok(pubkey_b64) = str::from_utf8(&bytes) else {
                                 log::error!(target: "tincd::auth",
@@ -974,10 +981,16 @@ impl Daemon {
                                 return needs_write;
                             };
 
+                            let current = replace.and_then(|_| {
+                                let cfg = keys::read_host_config(&self.hosts, &name);
+                                keys::read_ecdsa_public_key(&cfg, &self.hosts, &name)
+                            });
                             let host_path = match invitation_serve::finalize(
                                 &self.hosts,
                                 &name,
                                 pubkey_b64,
+                                replace.as_ref(),
+                                current.as_ref(),
                             ) {
                                 Ok(host_path) => {
                                     log::info!(target: "tincd::auth",
@@ -1008,7 +1021,30 @@ impl Daemon {
                                 cache.disarm();
                             }
 
-                            self.run_invitation_accepted_script(&name, &host_path, conn_addr);
+                            // Replace is revocation on this node: drop the
+                            // old device's session now, not on its next
+                            // reconnect.
+                            if replace.is_some() {
+                                let old: Vec<ConnId> = self
+                                    .conns
+                                    .iter()
+                                    .filter(|(cid, c)| *cid != id && !c.control && c.name == name)
+                                    .map(|(cid, _)| cid)
+                                    .collect();
+                                for cid in old {
+                                    log::info!(target: "tincd::auth",
+                                               "Closing connection with {name}: key replaced");
+                                    self.terminate(cid);
+                                }
+                            }
+
+                            let replaced = replace.map(|k| tinc_crypto::b64::encode(&k));
+                            self.run_invitation_accepted_script(
+                                &name,
+                                &host_path,
+                                replaced.as_deref(),
+                                conn_addr,
+                            );
 
                             // empty type-2 = ACK; joiner closes after
                             // reading it.
@@ -1043,12 +1079,16 @@ impl Daemon {
         &self,
         node: &str,
         host_file: &Path,
+        replaced: Option<&str>,
         addr: Option<SocketAddr>,
     ) {
         let mut env = ScriptEnv::base(None, &self.name, None, Some(&self.iface), None);
         env.add("NODE", node.to_owned());
         // With HostsOverlayDirectory the file is not at hosts/$NODE.
         env.add("HOST_FILE", host_file.display().to_string());
+        if let Some(k) = replaced {
+            env.add("REPLACE", k.to_owned());
+        }
         if let Some(a) = addr {
             env.add("REMOTEADDRESS", a.ip().to_string());
             env.add("REMOTEPORT", a.port().to_string());

--- a/crates/tincd/src/daemon/setup.rs
+++ b/crates/tincd/src/daemon/setup.rs
@@ -409,8 +409,11 @@ pub(super) fn read_daemon_config(
         .ok_or_else(|| SetupError::Config("Name for tinc daemon required!".into()))?;
     let name = expand_name(name).map_err(SetupError::Config)?;
     let hosts = HostDirs::from_config(confbase, &config);
-    for n in hosts.overridden() {
-        log::warn!(target: "tincd", "hosts/{n} is overridden by {}", hosts.file(&n).display());
+    let overridden = hosts.overridden();
+    if let Some(o) = hosts.overlay()
+        && !overridden.is_empty()
+    {
+        log::warn!(target: "tincd", "{} overrides hosts/ for: {}", o.display(), overridden.join(" "));
     }
     let host = keys::read_host_config(&hosts, &name);
     if host.entries().is_empty() {

--- a/crates/tincd/src/daemon/setup.rs
+++ b/crates/tincd/src/daemon/setup.rs
@@ -409,6 +409,9 @@ pub(super) fn read_daemon_config(
         .ok_or_else(|| SetupError::Config("Name for tinc daemon required!".into()))?;
     let name = expand_name(name).map_err(SetupError::Config)?;
     let hosts = HostDirs::from_config(confbase, &config);
+    for n in hosts.overridden() {
+        log::warn!(target: "tincd", "hosts/{n} is overridden by {}", hosts.file(&n).display());
+    }
     let host = keys::read_host_config(&hosts, &name);
     if host.entries().is_empty() {
         log::warn!(target: "tincd", "hosts/{name} empty or unreadable, using defaults");

--- a/crates/tincd/src/invitation_serve.rs
+++ b/crates/tincd/src/invitation_serve.rs
@@ -19,7 +19,9 @@ use std::time::{Duration, SystemTime};
 use tinc_conf::HostDirs;
 
 use tinc_conf::read_pem;
-use tinc_crypto::invite::cookie_filename;
+use tinc_crypto::b64;
+use tinc_crypto::invite::{cookie_filename, strip_replace_marker};
+use tinc_crypto::sign::PUBLIC_LEN;
 
 use std::io;
 use std::io::ErrorKind;
@@ -41,8 +43,12 @@ pub(crate) const CHUNK_SIZE: usize = 1024;
 pub(crate) enum InvitePhase {
     /// type != 0 || len != 18 → close.
     WaitingCookie,
-    /// `c->status.invitation_used = true`.
-    WaitingPubkey { name: String },
+    /// `c->status.invitation_used = true`. `replace` is the pinned old
+    /// key from a `tinc invite --replace` file.
+    WaitingPubkey {
+        name: String,
+        replace: Option<[u8; PUBLIC_LEN]>,
+    },
     /// Post-ACK terminal state; any further record terminates the conn.
     Done,
 }
@@ -63,6 +69,9 @@ pub(crate) enum ServeError {
     /// Don't overwrite: would replace a known key.
     #[error("host config file {} already exists", .0.display())]
     HostFileExists(PathBuf),
+    /// Replace-invite whose pinned key no longer matches the host file.
+    #[error("key of {0} changed since the invitation was issued; it is used up, issue a new one")]
+    KeyChanged(String),
     #[error("I/O error on {}: {err}", path.display())]
     Io {
         path: PathBuf,
@@ -124,7 +133,16 @@ fn parse_name_line(line: &str) -> Option<&str> {
     }
 }
 
-/// Type-0 (cookie) handler: returns `(file_contents, invited_name, used_path)`.
+#[derive(Debug)]
+pub(crate) struct Served {
+    /// What goes on the wire (replace marker stripped).
+    pub contents: Vec<u8>,
+    pub name: String,
+    pub replace: Option<[u8; PUBLIC_LEN]>,
+    pub used_path: PathBuf,
+}
+
+/// Type-0 (cookie) handler.
 ///
 /// # Errors
 /// `NonExisting` (rename ENOENT; single use is enforced by the atomic rename),
@@ -137,7 +155,7 @@ pub(crate) fn serve_cookie(
     myname: &str,
     invitation_lifetime: Duration,
     now: SystemTime,
-) -> Result<(Vec<u8>, String, PathBuf), ServeError> {
+) -> Result<Served, ServeError> {
     // :201-207
     let filename = cookie_filename(cookie, inv_key.public_key());
     let inv_dir = confbase.join("invitations");
@@ -169,11 +187,21 @@ pub(crate) fn serve_cookie(
     }
 
     // :240-257
-    let contents = fs::read(&used_path).map_err(io_err(&used_path))?;
+    let raw = fs::read(&used_path).map_err(io_err(&used_path))?;
+    let (replace, contents) = strip_replace_marker(&raw);
+    let replace = replace
+        .map(|k| {
+            str::from_utf8(k)
+                .ok()
+                .and_then(b64::decode)
+                .and_then(|v| v.try_into().ok())
+                .ok_or_else(|| ServeError::BadInvitationFile("bad #replace key".into()))
+        })
+        .transpose()?;
     let first_line = contents
         .iter()
         .position(|&b| b == b'\n')
-        .map_or(&contents[..], |i| &contents[..i]);
+        .map_or(contents, |i| &contents[..i]);
     let first_line = str::from_utf8(first_line)
         .map_err(|_| ServeError::BadInvitationFile("first line not UTF-8".into()))?;
 
@@ -186,20 +214,27 @@ pub(crate) fn serve_cookie(
             ServeError::BadInvitationFile(format!("first line not `Name = X`: {first_line:?}"))
         })?;
 
-    Ok((contents, invited_name, used_path))
+    Ok(Served {
+        contents: contents.to_vec(),
+        name: invited_name,
+        replace,
+        used_path,
+    })
 }
 
-/// Type-1 handler: writes the host file, into the overlay when one is
-/// configured. Addrcache, script, unlink and the type-2 reply are
-/// daemon-side.
+/// Type-1 handler: writes the host file at `write_path`. For a
+/// replace-invite, `replace` is the pinned old key and `current` the key
+/// the daemon reads for `name` right now.
 ///
 /// # Errors
-/// `BadPubkey` on a newline (config injection). `HostFileExists` when the
-/// name exists in either directory, so an invitee cannot replace a key.
+/// `BadPubkey` (config injection), `HostFileExists` (fresh invite for a
+/// known name), `KeyChanged` (pin does not match).
 pub(crate) fn finalize(
     hosts: &HostDirs,
     name: &str,
     pubkey_b64: &str,
+    replace: Option<&[u8; PUBLIC_LEN]>,
+    current: Option<&[u8; PUBLIC_LEN]>,
 ) -> Result<PathBuf, ServeError> {
     // Ed25519 pubkey: 32 bytes → exactly 43 chars of unpadded tinc-
     // base64. `b64::decode` rejects anything outside the union
@@ -211,13 +246,21 @@ pub(crate) fn finalize(
         return Err(ServeError::BadPubkey);
     }
 
-    if hosts.exists(name) {
-        return Err(ServeError::HostFileExists(hosts.file(name)));
-    }
     if let Some(o) = hosts.overlay() {
         fs::create_dir_all(o).map_err(io_err(o))?;
     }
     let host_path = hosts.write_path(name);
+    if let Some(pinned) = replace {
+        if current != Some(pinned) {
+            return Err(ServeError::KeyChanged(name.to_owned()));
+        }
+        let old = fs::read_to_string(hosts.file(name)).map_err(io_err(&hosts.file(name)))?;
+        write_replaced(&host_path, &old, pubkey_b64)?;
+        return Ok(host_path);
+    }
+    if hosts.exists(name) {
+        return Err(ServeError::HostFileExists(hosts.file(name)));
+    }
 
     // :128-134. C: access() then fopen("w") — TOCTOU. We: O_CREAT|O_EXCL.
     let mut f = fs::OpenOptions::new()
@@ -240,6 +283,63 @@ pub(crate) fn finalize(
     writeln!(f, "Ed25519PublicKey = {pubkey_b64}").map_err(io_err(&host_path))?;
 
     Ok(host_path)
+}
+
+/// `old` with every Ed25519 public key form removed and the new key
+/// appended, written via tmp + rename so a reader never sees half a file.
+fn write_replaced(host_path: &Path, old: &str, pubkey_b64: &str) -> Result<(), ServeError> {
+    let mut out = String::with_capacity(old.len() + 64);
+    let mut in_pem = false;
+    for line in old.lines() {
+        if in_pem {
+            in_pem = !line.starts_with("-----END ED25519 PUBLIC KEY-----");
+            continue;
+        }
+        if line.starts_with("-----BEGIN ED25519 PUBLIC KEY-----") {
+            in_pem = true;
+            continue;
+        }
+        let key = split_var(line).map_or("", |(k, _)| k);
+        if key.eq_ignore_ascii_case("Ed25519PublicKey")
+            || key.eq_ignore_ascii_case("Ed25519PublicKeyFile")
+        {
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("Ed25519PublicKey = ");
+    out.push_str(pubkey_b64);
+    out.push('\n');
+
+    let tmp = host_path.with_extension("tmp");
+    let write = || -> io::Result<()> {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(nix::fcntl::OFlag::O_NOFOLLOW.bits())
+            .open(&tmp)?;
+        f.write_all(out.as_bytes())?;
+        fs::rename(&tmp, host_path)
+    };
+    write().map_err(|err| {
+        let _ = fs::remove_file(&tmp);
+        if matches!(
+            err.kind(),
+            ErrorKind::PermissionDenied | ErrorKind::ReadOnlyFilesystem
+        ) {
+            ServeError::BadInvitationFile(format!(
+                "{} is not writable, set HostsOverlayDirectory",
+                host_path.display()
+            ))
+        } else {
+            ServeError::Io {
+                path: host_path.to_owned(),
+                err,
+            }
+        }
+    })
 }
 
 /// Use [`CHUNK_SIZE`] for wire parity.
@@ -285,11 +385,16 @@ mod tests {
         let body = "Name = bob\nAddress = 192.0.2.1\n";
         let (tmp, cookie) = setup_invitation("roundtrip", &key, body);
 
-        let (contents, name, used_path) =
-            serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
+        let Served {
+            contents,
+            name,
+            replace,
+            used_path,
+        } = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
 
         assert_eq!(contents, body.as_bytes());
         assert_eq!(name, "bob");
+        assert!(replace.is_none());
 
         assert!(used_path.exists(), ".used file should exist");
         assert!(
@@ -322,8 +427,9 @@ mod tests {
         let key = test_key();
         let (tmp, cookie) = setup_invitation("single-use", &key, "Name = bob\n");
 
-        let (_, name, _) =
-            serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
+        let name = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now())
+            .unwrap()
+            .name;
         assert_eq!(name, "bob");
 
         // Second call: original gone → ENOENT → NonExisting.
@@ -402,7 +508,7 @@ mod tests {
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
 
         let pk = valid_pubkey_b64();
-        let path = finalize(&HostDirs::new(tmp.path(), None), "bob", &pk).unwrap();
+        let path = finalize(&HostDirs::new(tmp.path(), None), "bob", &pk, None, None).unwrap();
 
         assert_eq!(path, tmp.path().join("hosts").join("bob"));
         let written = fs::read_to_string(&path).unwrap();
@@ -415,7 +521,14 @@ mod tests {
         let tmp = TmpDir::new("fin-newline");
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
 
-        let err = finalize(&HostDirs::new(tmp.path(), None), "bob", "evil\nPort = 0").unwrap_err();
+        let err = finalize(
+            &HostDirs::new(tmp.path(), None),
+            "bob",
+            "evil\nPort = 0",
+            None,
+            None,
+        )
+        .unwrap_err();
         assert!(matches!(err, ServeError::BadPubkey));
         assert!(!tmp.path().join("hosts").join("bob").exists());
     }
@@ -431,12 +544,13 @@ mod tests {
         let bad_charset = format!("{}=", &good[..42]);
 
         for bad in [&good[..42], too_long.as_str(), bad_charset.as_str()] {
-            let err = finalize(&HostDirs::new(tmp.path(), None), "bob", bad).unwrap_err();
+            let err =
+                finalize(&HostDirs::new(tmp.path(), None), "bob", bad, None, None).unwrap_err();
             assert!(matches!(err, ServeError::BadPubkey), "{bad:?}: {err:?}");
             assert!(!tmp.path().join("hosts").join("bob").exists());
         }
 
-        finalize(&HostDirs::new(tmp.path(), None), "bob", &good).unwrap();
+        finalize(&HostDirs::new(tmp.path(), None), "bob", &good, None, None).unwrap();
     }
 
     #[test]
@@ -446,11 +560,67 @@ mod tests {
         let host = tmp.path().join("hosts").join("bob");
         fs::write(&host, "Ed25519PublicKey = original\n").unwrap();
 
-        let err =
-            finalize(&HostDirs::new(tmp.path(), None), "bob", &valid_pubkey_b64()).unwrap_err();
+        let err = finalize(
+            &HostDirs::new(tmp.path(), None),
+            "bob",
+            &valid_pubkey_b64(),
+            None,
+            None,
+        )
+        .unwrap_err();
         assert!(matches!(err, ServeError::HostFileExists(_)));
         let after = fs::read_to_string(&host).unwrap();
         assert_eq!(after, "Ed25519PublicKey = original\n");
+    }
+
+    /// The replace marker is parsed off and never reaches the invitee.
+    #[test]
+    fn serve_cookie_strips_replace_marker() {
+        let key = test_key();
+        let old = b64::encode(&[9u8; PUBLIC_LEN]);
+        let body = format!("#replace {old}\nName = bob\nConnectTo = alice\n");
+        let (tmp, cookie) = setup_invitation("replace", &key, &body);
+        let s = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
+        assert_eq!(s.contents, b"Name = bob\nConnectTo = alice\n");
+        assert_eq!(s.name, "bob");
+        assert_eq!(s.replace, Some([9u8; PUBLIC_LEN]));
+    }
+
+    /// Replace keeps everything but the key lines, writes to the overlay,
+    /// and only when the pinned key is still the current one.
+    #[test]
+    fn finalize_replace() {
+        let tmp = TmpDir::new("fin-replace");
+        let overlay = tmp.path().join("ov");
+        fs::create_dir_all(tmp.path().join("hosts")).unwrap();
+        let dirs = HostDirs::new(tmp.path(), Some(overlay.clone()));
+        let old = [1u8; PUBLIC_LEN];
+        fs::write(
+            tmp.path().join("hosts/bob"),
+            format!(
+                "# Bob <bob@example.org>\nSubnet = 10.0.0.7\nEd25519PublicKeyFile = x\n\
+                 ed25519publickey = {}\n-----BEGIN ED25519 PUBLIC KEY-----\nabc\n\
+                 -----END ED25519 PUBLIC KEY-----\nPort = 655\n",
+                b64::encode(&old)
+            ),
+        )
+        .unwrap();
+        let new = valid_pubkey_b64();
+
+        let err = finalize(&dirs, "bob", &new, Some(&old), Some(&[2u8; PUBLIC_LEN])).unwrap_err();
+        assert!(matches!(err, ServeError::KeyChanged(_)));
+        let err = finalize(&dirs, "bob", &new, Some(&old), None).unwrap_err();
+        assert!(matches!(err, ServeError::KeyChanged(_)));
+        assert!(!overlay.join("bob").exists());
+
+        let path = finalize(&dirs, "bob", &new, Some(&old), Some(&old)).unwrap();
+        assert_eq!(path, overlay.join("bob"));
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            format!(
+                "# Bob <bob@example.org>\nSubnet = 10.0.0.7\nPort = 655\nEd25519PublicKey = {new}\n"
+            )
+        );
     }
 
     /// With an overlay, invited hosts land there and a read-only `hosts/`
@@ -463,12 +633,12 @@ mod tests {
         fs::create_dir_all(&overlay).unwrap();
         let dirs = HostDirs::new(tmp.path(), Some(overlay.clone()));
 
-        let path = finalize(&dirs, "bob", &valid_pubkey_b64()).unwrap();
+        let path = finalize(&dirs, "bob", &valid_pubkey_b64(), None, None).unwrap();
         assert_eq!(path, overlay.join("bob"));
         assert!(!tmp.path().join("hosts/bob").exists());
 
         fs::write(tmp.path().join("hosts/carol"), "").unwrap();
-        let err = finalize(&dirs, "carol", &valid_pubkey_b64()).unwrap_err();
+        let err = finalize(&dirs, "carol", &valid_pubkey_b64(), None, None).unwrap_err();
         assert!(matches!(err, ServeError::HostFileExists(_)));
         assert!(!overlay.join("carol").exists());
     }

--- a/crates/tincd/tests/two_daemons/reload.rs
+++ b/crates/tincd/tests/two_daemons/reload.rs
@@ -1,5 +1,5 @@
 use nix::sys::signal::Signal;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use super::common::node::has_subnet;
 use super::common::{
@@ -227,6 +227,82 @@ fn identity_only_join_registers_key_and_peer_connects() {
     // Not the harness key: the one the join generated.
     fs::remove_file(bob.confbase.join("ed25519_key.priv")).unwrap();
     bob.start();
+    alice.wait_for_peer("bob", true, Duration::from_secs(10));
+}
+
+/// `tinc invite --replace bob` on alice while the old bob is connected:
+/// a new device joins under bob's name, alice keeps bob's Subnet, swaps
+/// the key (into the overlay, `hosts/` untouched), kicks the old bob and
+/// no longer lets it in; the new key does get in.
+#[test]
+fn replace_invite_rekeys_node_and_drops_old_device() {
+    let tmp = tmp!("replace");
+    let mut alice =
+        Node::new(tmp.path(), "alice", 0xAA).with_conf("HostsOverlayDirectory = hosts.local\n");
+    let mut bob = Node::new(tmp.path(), "bob", 0xBB);
+    bob.start_dialing(&mut alice);
+    let hosts_bob = alice.confbase.join("hosts/bob");
+    fs::write(
+        &hosts_bob,
+        fs::read_to_string(&hosts_bob).unwrap() + "Subnet = 10.0.0.7/32\n",
+    )
+    .unwrap();
+    let hook = alice.confbase.join("invitation-accepted");
+    let hook_out = alice.confbase.join("hook.out");
+    fs::write(
+        &hook,
+        format!("#!/bin/sh\necho \"$REPLACE\" > '{}'\n", hook_out.display()),
+    )
+    .unwrap();
+    fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Real `tinc invite --replace`: needs alice's Address for the URL.
+    let hosts_alice = alice.confbase.join("hosts/alice");
+    fs::write(
+        &hosts_alice,
+        fs::read_to_string(&hosts_alice).unwrap()
+            + &format!("Address = 127.0.0.1 {}\n", alice.port),
+    )
+    .unwrap();
+    let alice_paths = cli_paths(alice.confbase.clone());
+    let err = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", false, SystemTime::now())
+        .unwrap_err();
+    assert!(err.to_string().contains("already exists"), "{err}");
+    let url = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", true, SystemTime::now())
+        .unwrap()
+        .url;
+    assert_eq!(alice.ctl().reload(), 0);
+
+    let key = tmp.path().join("newbob.priv");
+    if let Err(err) = tinc_tools::cmd::join::join(&url, &Mode::IdentityOnly(Some(key.clone()))) {
+        panic!("join: {err:?}\nalice:\n{}", alice.stop());
+    }
+
+    let old_b64 = tinc_crypto::b64::encode(&bob.pubkey());
+    let overlay_bob = alice.confbase.join("hosts.local/bob");
+    assert!(wait_for_file(&overlay_bob));
+    let new_host = fs::read_to_string(&overlay_bob).unwrap();
+    assert!(
+        new_host.starts_with("Subnet = 10.0.0.7/32\nEd25519PublicKey = "),
+        "{new_host}"
+    );
+    assert!(!new_host.contains(&old_b64));
+    assert!(fs::read_to_string(&hosts_bob).unwrap().contains(&old_b64));
+    assert!(wait_for_file(&hook_out));
+    assert_eq!(fs::read_to_string(&hook_out).unwrap().trim(), old_b64);
+
+    // Old bob was kicked and, retrying with the old key, stays out.
+    alice.wait_for_peer("bob", false, Duration::from_secs(10));
+    thread::sleep(Duration::from_millis(1500));
+    assert!(!alice.has_active_peer("bob"), "old key got back in");
+    bob.stop();
+
+    // New device with the joined key connects as bob.
+    let mut newbob = Node::new(tmp.path(), "bob", 0xBB)
+        .with_conf(&format!("Ed25519PrivateKeyFile = {}\n", key.display()));
+    newbob.write_config_multi(&[&alice], &[&alice]);
+    fs::remove_file(newbob.confbase.join("ed25519_key.priv")).unwrap();
+    newbob.start();
     alice.wait_for_peer("bob", true, Duration::from_secs(10));
 }
 

--- a/docs/COMPAT.md
+++ b/docs/COMPAT.md
@@ -67,7 +67,12 @@ participate.
   unit file doesn't need `-d` flags.
 - **`HostsOverlayDirectory` config key.** Second host directory for
   deployments where `hosts/` is read-only. Invited nodes are written
-  there and `invitation-accepted` gets the path in `HOST_FILE`.
+  there, override `hosts/`, and `invitation-accepted` gets the path in
+  `HOST_FILE`.
+- **`tinc invite --replace NODE`.** Re-keys an existing node through an
+  invitation (new phone, lost key). The invitation file starts with
+  `#replace <oldkey>`; a C tincd serving such a file refuses the join
+  with "host file exists", so it fails safe in mixed setups.
 - **`SPTPSCipher` host key.** Selects AES-256-GCM instead of
   ChaCha20-Poly1305 for the SPTPS record AEAD on a per-edge basis.
   On AES-NI/PMULL hardware this roughly doubles tunnel throughput.

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -107,8 +107,9 @@ set `ed25519PrivateKeyFile` to the decrypted path, deploy. Without
 
 Since `hosts/` lives in the store,
 the module sets `HostsOverlayDirectory = /var/lib/tincr/<net>/hosts`:
-nodes that accept an invitation are written there and stay valid
-across deploys until they are added to `hosts` proper.
+nodes that accept an invitation are written there and override the
+deployed copy until removed (prune entries that match `hosts` after a
+deploy).
 
 Set `socketActivation = false` to start the daemon at boot
 (`multi-user.target`) instead of on the first inbound connection.

--- a/man/tinc.8
+++ b/man/tinc.8
@@ -144,10 +144,21 @@ overwrite existing files.
 .Pq or Cm export-all
 followed by
 .Cm import .
-.It Cm invite Ar NODE
+.It Cm invite Oo Fl -replace Oc Ar NODE
 Generate an invitation URL for
 .Ar NODE
 and print it to stdout.
+With
+.Fl -replace ,
+.Ar NODE
+must already exist: its current Ed25519 key is pinned in the
+invitation and the device that joins takes over the name, keeping the
+rest of the host file (Subnet, Address, ...).
+The join fails if the key changed in between.
+Any live connection of the old device is closed.
+Both invitation scripts see the replaced key in
+.Ev REPLACE .
+tincr only.
 .It Cm join Oo Fl -identity-only Ns Oo = Ns Ar FILE Oc Oc Op Ar URL
 Join a network using an invitation URL (read from stdin if omitted).
 With

--- a/man/tinc.conf.5
+++ b/man/tinc.conf.5
@@ -178,7 +178,8 @@ Host files accepted through invitations and keys replaced with
 are written here.
 An entry here overrides the one in
 .Pa hosts/
-(logged at startup); remove it once the deployed copy has caught up.
+(logged at startup and reload); remove it once the deployed copy has
+caught up.
 Relative to the configuration directory.
 The
 .Pa invitation-accepted

--- a/man/tinc.conf.5
+++ b/man/tinc.conf.5
@@ -173,13 +173,12 @@ Reject invitations older than this.
 Second host directory for setups where
 .Pa hosts/
 is deployed read-only.
-Host files accepted through invitations are written here, and lookups
-fall back to it when a name is missing from
-.Pa hosts/ .
-An entry in
+Host files accepted through invitations and keys replaced with
+.Nm tinc Cm invite Fl -replace
+are written here.
+An entry here overrides the one in
 .Pa hosts/
-always wins, so a node graduating into the deployed set shadows its
-overlay copy.
+(logged at startup); remove it once the deployed copy has caught up.
 Relative to the configuration directory.
 The
 .Pa invitation-accepted


### PR DESCRIPTION
- `HostsOverlayDirectory`: overlay now overrides `hosts/` (was the other way round); overridden names are logged on start/reload.
- `tinc invite --replace NODE`: NODE must exist; its current Ed25519 key is pinned as `#replace <key>` on the first line of the invitation; `invitation-created` gets `REPLACE=<key>`.
- tincd strips the marker before sending, checks the pin against the key it currently reads for NODE, rewrites the host file with only the key swapped (tmp+rename, overlay if set), closes the old device's connection, and passes `REPLACE` to `invitation-accepted`.
- `dump invitations` skips the marker; man pages and COMPAT updated.
