### PR TITLE
hostdirs: overlay overrides hosts/

### DIFF
--- a/crates/tinc-conf/src/hostdirs.rs
+++ b/crates/tinc-conf/src/hostdirs.rs
@@ -1,9 +1,10 @@
 //! `hosts/` plus an optional `HostsOverlayDirectory`.
 //!
 //! On managed systems `hosts/` is deployed read-only from a registry.
-//! Accepted invitations are written to the overlay instead, so a deploy
-//! never clobbers them. Lookups try `hosts/` first and fall back to the
-//! overlay, which means the registry copy wins once a node lands there.
+//! Runtime writes (accepted invitations, replaced keys) go to the overlay
+//! so a deploy never clobbers them. The overlay wins on lookup, like
+//! `/etc` over `/usr/lib`. Entries there are meant to be pruned once the
+//! registry copy has caught up.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -39,19 +40,30 @@ impl HostDirs {
         Self::new(confbase, overlay)
     }
 
-    /// Path to read `name` from. Prefers `hosts/`, then the overlay. When
+    /// Path to read `name` from. Prefers the overlay, then `hosts/`. When
     /// neither has it, returns the `hosts/` path so error messages point
     /// there.
     #[must_use]
     pub fn file(&self, name: &str) -> PathBuf {
-        let p = self.primary.join(name);
-        if present(&p) {
-            return p;
-        }
         match &self.overlay {
             Some(o) if present(&o.join(name)) => o.join(name),
-            _ => p,
+            _ => self.primary.join(name),
         }
+    }
+
+    /// Names present in both dirs, where the overlay copy masks the
+    /// deployed one.
+    #[must_use]
+    pub fn overridden(&self) -> Vec<String> {
+        let Some(o) = &self.overlay else {
+            return Vec::new();
+        };
+        let mut names = BTreeSet::new();
+        let _ = collect(o, &mut names);
+        names
+            .into_iter()
+            .filter(|n| present(&self.primary.join(n)))
+            .collect()
     }
 
     /// Any directory entry for `name` in either dir, dangling symlinks
@@ -120,8 +132,8 @@ mod tests {
     use super::*;
     use std::os::unix::fs::symlink;
 
-    /// A dangling symlink in `hosts/` still occupies the name. Falling
-    /// through to the overlay would let an invitee claim it.
+    /// A dangling symlink still occupies the name, so an invitee cannot
+    /// claim it.
     #[test]
     fn dangling_symlink_occupies_name() {
         let tmp = tempfile::tempdir().unwrap();
@@ -129,11 +141,12 @@ mod tests {
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
         fs::create_dir_all(&ov).unwrap();
         symlink("/nonexistent", tmp.path().join("hosts/bob")).unwrap();
-        fs::write(ov.join("bob"), "").unwrap();
-        let d = HostDirs::new(tmp.path(), Some(ov));
+        symlink("/nonexistent", ov.join("carol")).unwrap();
+        let d = HostDirs::new(tmp.path(), Some(ov.clone()));
         assert!(d.exists("bob"));
-        assert_eq!(d.file("bob"), tmp.path().join("hosts/bob"));
-        assert!(!d.exists("carol"));
+        assert!(d.exists("carol"));
+        assert_eq!(d.file("carol"), ov.join("carol"));
+        assert!(!d.exists("dave"));
     }
 
     /// A missing overlay is normal before the first join. An unreadable one
@@ -163,17 +176,19 @@ mod tests {
     }
 
     #[test]
-    fn primary_shadows_overlay() {
+    fn overlay_overrides_primary() {
         let tmp = tempfile::tempdir().unwrap();
         let ov = tmp.path().join("hosts.local");
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
         fs::create_dir_all(&ov).unwrap();
         let d = HostDirs::new(tmp.path(), Some(ov.clone()));
 
-        fs::write(ov.join("bob"), "").unwrap();
-        assert_eq!(d.file("bob"), ov.join("bob"));
         fs::write(tmp.path().join("hosts/bob"), "").unwrap();
         assert_eq!(d.file("bob"), tmp.path().join("hosts/bob"));
+        assert!(d.overridden().is_empty());
+        fs::write(ov.join("bob"), "").unwrap();
+        assert_eq!(d.file("bob"), ov.join("bob"));
+        assert_eq!(d.overridden(), ["bob"]);
 
         assert_eq!(d.file("nobody"), tmp.path().join("hosts/nobody"));
         assert_eq!(d.write_path("carol"), ov.join("carol"));

--- a/crates/tinc-tools/src/cmd/exchange.rs
+++ b/crates/tinc-tools/src/cmd/exchange.rs
@@ -374,7 +374,7 @@ mod tests {
     }
 
     /// Nodes the daemon accepted into `HostsOverlayDirectory` are peers
-    /// too. `hosts/` wins when both have the name.
+    /// too. The overlay wins when both have the name.
     #[test]
     fn export_all_includes_overlay() {
         let cd = setup("alice", "Subnet = 10.0.1.0/24\n")
@@ -384,7 +384,7 @@ mod tests {
         export_all(cd.paths(), &mut out).unwrap();
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("Name = bob\nSubnet = 10.0.2.0/24"), "{s}");
-        assert!(!s.contains("6.6.6.6"), "{s}");
+        assert!(!s.contains("10.0.1.0"), "{s}");
         assert_eq!(s.matches("Name = alice").count(), 1);
     }
 

--- a/crates/tincd/src/daemon/setup.rs
+++ b/crates/tincd/src/daemon/setup.rs
@@ -409,6 +409,9 @@ pub(super) fn read_daemon_config(
         .ok_or_else(|| SetupError::Config("Name for tinc daemon required!".into()))?;
     let name = expand_name(name).map_err(SetupError::Config)?;
     let hosts = HostDirs::from_config(confbase, &config);
+    for n in hosts.overridden() {
+        log::warn!(target: "tincd", "hosts/{n} is overridden by {}", hosts.file(&n).display());
+    }
     let host = keys::read_host_config(&hosts, &name);
     if host.entries().is_empty() {
         log::warn!(target: "tincd", "hosts/{name} empty or unreadable, using defaults");

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -107,8 +107,9 @@ set `ed25519PrivateKeyFile` to the decrypted path, deploy. Without
 
 Since `hosts/` lives in the store,
 the module sets `HostsOverlayDirectory = /var/lib/tincr/<net>/hosts`:
-nodes that accept an invitation are written there and stay valid
-across deploys until they are added to `hosts` proper.
+nodes that accept an invitation are written there and override the
+deployed copy until removed. Prune entries that match `hosts` after a
+deploy.
 
 Set `socketActivation = false` to start the daemon at boot
 (`multi-user.target`) instead of on the first inbound connection.

--- a/man/tinc.conf.5
+++ b/man/tinc.conf.5
@@ -173,13 +173,13 @@ Reject invitations older than this.
 Second host directory for setups where
 .Pa hosts/
 is deployed read-only.
-Host files accepted through invitations are written here, and lookups
-fall back to it when a name is missing from
-.Pa hosts/ .
-An entry in
-.Pa hosts/
-always wins, so a node graduating into the deployed set shadows its
-overlay copy.
+Host files accepted through invitations and keys replaced with
+.Nm tinc Cm invite Fl -replace
+are written here.
+An entry here overrides the one in
+.Pa hosts/ ,
+which is logged at startup and reload.
+Remove it once the deployed copy has caught up.
 Relative to the configuration directory.
 The
 .Pa invitation-accepted


### PR DESCRIPTION
Overlay entries now override `hosts/` instead of the other way round, so keys written at runtime take effect without waiting for a deploy. Overridden names are logged on start and reload.
