### PR TITLE
tinc invite: add --replace

### DIFF
--- a/crates/tinc-crypto/src/invite.rs
+++ b/crates/tinc-crypto/src/invite.rs
@@ -70,6 +70,21 @@ pub const SLUG_PART_LEN: usize = 24;
 /// Full slug length: `b64(key_hash) || b64(cookie)`.
 pub const SLUG_LEN: usize = 2 * SLUG_PART_LEN;
 
+/// First line of a replace-invitation: `#replace <old-b64-pubkey>`. tincr
+/// only. The daemon strips it before sending, so `tinc join` never sees it.
+pub const REPLACE_MARKER: &str = "#replace ";
+
+/// Split an optional replace marker off an invitation file. Returns the
+/// pinned old key (still b64) and the remainder starting at `Name =`.
+#[must_use]
+pub fn strip_replace_marker(contents: &[u8]) -> (Option<&[u8]>, &[u8]) {
+    let Some(rest) = contents.strip_prefix(REPLACE_MARKER.as_bytes()) else {
+        return (None, contents);
+    };
+    let nl = rest.iter().position(|&b| b == b'\n').unwrap_or(rest.len());
+    (Some(&rest[..nl]), rest.get(nl + 1..).unwrap_or_default())
+}
+
 // Compile-time witness that 18 → 24 is the encoding length we claimed.
 // b64 length for n bytes (no padding) is `(n*4).div_ceil(3)`. 18*4/3 = 24
 // exactly, no ceil needed. If someone bumps COOKIE_LEN this fires.
@@ -196,6 +211,22 @@ pub fn parse_slug(slug: &str) -> Option<([u8; COOKIE_LEN], [u8; COOKIE_LEN])> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replace_marker() {
+        assert_eq!(
+            strip_replace_marker(b"Name = a\n"),
+            (None, &b"Name = a\n"[..])
+        );
+        assert_eq!(
+            strip_replace_marker(b"#replace abc\nName = a\n"),
+            (Some(&b"abc"[..]), &b"Name = a\n"[..])
+        );
+        assert_eq!(
+            strip_replace_marker(b"#replace abc"),
+            (Some(&b"abc"[..]), &b""[..])
+        );
+    }
 
     /// `key_hash(pk) == fingerprint_hash(fingerprint(pk))`. The KAT
     /// proves `key_hash` matches C; this proves `fingerprint_hash`

--- a/crates/tinc-tools/src/bin/tinc.rs
+++ b/crates/tinc-tools/src/bin/tinc.rs
@@ -190,7 +190,7 @@ const COMMANDS: &[CmdEntry] = &[
         // unredeemable until manual restart.
         needs_daemon: true,
         run: Run::Any(cmd_invite),
-        help: "invite NODE            Generate an invitation for NODE.",
+        help: "invite [--replace] NODE  Generate an invitation for NODE.\n    --replace - let a new device take over NODE's name, replacing its key",
     },
     CmdEntry {
         name: "join",
@@ -481,6 +481,10 @@ fn cmd_fsck(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError>
 /// `tinc invite alice | mail alice@example` works). Warnings to
 /// stderr.
 fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError> {
+    let (replace, args) = match args.split_first() {
+        Some((a, rest)) if a == "--replace" => (true, rest),
+        _ => (false, args),
+    };
     let [invitee] = args else {
         return Err(if args.is_empty() {
             CmdError::MissingArg("node name")
@@ -489,7 +493,13 @@ fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdErro
         });
     };
 
-    let r = cmd::invite::invite(paths, g.netname.as_deref(), invitee, SystemTime::now())?;
+    let r = cmd::invite::invite(
+        paths,
+        g.netname.as_deref(),
+        invitee,
+        replace,
+        SystemTime::now(),
+    )?;
 
     if r.key_is_new {
         // The daemon loads `invitations/ed25519_key.priv` at startup;

--- a/crates/tinc-tools/src/cmd/dump.rs
+++ b/crates/tinc-tools/src/cmd/dump.rs
@@ -34,7 +34,7 @@ use crate::names::{Paths, check_id};
 // Re-exported so existing `cmd::dump::{NodeRow,…}` paths keep working.
 pub use crate::ctl::rows::{ConnRow, EdgeRow, NodeRow, StatusBit, SubnetRow, strip_weight};
 use std::io::ErrorKind;
-use tinc_crypto::invite::SLUG_PART_LEN;
+use tinc_crypto::invite::{REPLACE_MARKER, SLUG_PART_LEN};
 
 /// Which `dump` sub-verb.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,9 +177,16 @@ pub fn dump_invitations(paths: &Paths) -> Result<Vec<InviteRow>, CmdError> {
         let Ok(file) = fs::File::open(&path) else {
             continue;
         };
+        let mut rd = BufReader::new(file);
         let mut first = String::new();
-        if BufReader::new(file).read_line(&mut first).is_err() || first.is_empty() {
+        if rd.read_line(&mut first).is_err() || first.is_empty() {
             continue;
+        }
+        if first.starts_with(REPLACE_MARKER) {
+            first.clear();
+            if rd.read_line(&mut first).is_err() {
+                continue;
+            }
         }
 
         // Route through the canonical split_kv so a hand-edited `Name=bob`

--- a/crates/tinc-tools/src/cmd/dump/tests.rs
+++ b/crates/tinc-tools/src/cmd/dump/tests.rs
@@ -495,6 +495,7 @@ fn inv_valid_table() {
         // Same tokenizer as tinc.conf — a hand-edited `Name=bob` must
         // list even though invite always writes the spaced form.
         ("no-space `=`",                "Name=bob\n"),
+        ("replace marker",              "#replace abc\nName = bob\n"),
     ];
     for (label, content) in cases {
         let (d, paths) = setup_inv();
@@ -661,7 +662,7 @@ fn inv_roundtrip_with_invite() {
 
     // `now` is parameterized for sweep_expired tests; pass real time.
     let now = SystemTime::now();
-    let result = invite::invite(&paths, None, "bob", now).unwrap();
+    let result = invite::invite(&paths, None, "bob", false, now).unwrap();
     // Only the written file matters here, not the returned URL.
     let _ = result;
 

--- a/crates/tinc-tools/src/cmd/invite.rs
+++ b/crates/tinc-tools/src/cmd/invite.rs
@@ -54,7 +54,8 @@ use std::time::{Duration, SystemTime};
 
 use rand_core::Rng;
 use tinc_conf::Config;
-use tinc_crypto::invite::{COOKIE_LEN, SLUG_PART_LEN, build_slug, cookie_filename};
+use tinc_crypto::b64;
+use tinc_crypto::invite::{COOKIE_LEN, REPLACE_MARKER, SLUG_PART_LEN, build_slug, cookie_filename};
 use tinc_crypto::os_rng;
 use tinc_crypto::sign::SigningKey;
 use zeroize::Zeroizing;
@@ -103,10 +104,10 @@ pub struct InviteResult {
     pub key_is_new: bool,
 }
 
-/// `tinc invite NODENAME`. `now` is injectable for tests; `netname` feeds the
-/// invitation's `NetName =` line (`Paths` only has the resolved confbase). One
-/// sequence of validate, mkdir, sweep, key, hash, file, url sharing local
-/// state.
+/// `tinc invite [--replace] NODENAME`. `now` is injectable for tests. With
+/// `replace`, NODENAME must already exist. Its current Ed25519 key is
+/// pinned in the invitation so the daemon swaps exactly that key at join
+/// time.
 ///
 /// # Errors
 /// `BadInput` (invalid or taken name, no `Address` configured) or `Io`.
@@ -114,6 +115,7 @@ pub fn invite(
     paths: &Paths,
     netname: Option<&str>,
     invitee: &str,
+    replace: bool,
     now: SystemTime,
 ) -> Result<InviteResult, CmdError> {
     if !check_id(invitee) {
@@ -125,13 +127,35 @@ pub fn invite(
     // Needed for the `ConnectTo` line and the host config dump.
     let myname = get_my_name(paths)?;
 
-    // Known in `hosts/` or the overlay. The daemon would refuse the join,
-    // so refuse to mint the URL.
-    if paths.host_dirs().exists(invitee) {
-        return Err(CmdError::BadInput(format!(
-            "A host config file for {invitee} already exists!"
-        )));
-    }
+    let hosts = paths.host_dirs();
+    let old_key = if replace {
+        if invitee == myname {
+            return Err(CmdError::BadInput("Cannot replace myself".into()));
+        }
+        if !hosts.exists(invitee) {
+            return Err(CmdError::BadInput(format!(
+                "No host config file for {invitee}, nothing to replace"
+            )));
+        }
+        let file = hosts.file(invitee);
+        let cfg = Config::read(&file).map_err(|e| CmdError::BadInput(e.to_string()))?;
+        let key = keypair::load_public_from_config(&cfg, &file).ok_or_else(|| {
+            CmdError::BadInput(format!(
+                "{} has no Ed25519 public key to replace",
+                file.display()
+            ))
+        })?;
+        Some(b64::encode(&key))
+    } else {
+        // The daemon refuses a join for a known name, so do not mint a
+        // URL for one.
+        if hosts.exists(invitee) {
+            return Err(CmdError::BadInput(format!(
+                "A host config file for {invitee} already exists! (--replace issues a new key for it)"
+            )));
+        }
+        None
+    };
 
     // Get our address (for the URL host part) early, so a no-Address
     // failure happens before any files are created.
@@ -198,7 +222,10 @@ pub fn invite(
     // Write the invitation file, O_EXCL 0600 (an 18-byte random cookie can't
     // collide, so EEXIST is a real problem). Built as one string and written once:
     // testable builder, no partial writes.
-    let body = build_invitation_file(paths, netname, invitee, &myname, &address)?;
+    let mut body = build_invitation_file(paths, netname, invitee, &myname, &address)?;
+    if let Some(k) = &old_key {
+        body.insert_str(0, &format!("{REPLACE_MARKER}{k}\n"));
+    }
     write_invitation_file(&inv_path, &body)?;
 
     // Build the URL
@@ -206,7 +233,16 @@ pub fn invite(
     let slug = Zeroizing::new(build_slug(pubkey, &cookie));
     let url = Zeroizing::new(format!("{address}/{}", *slug));
 
-    if let Err(e) = run_created_hook(paths, netname, &myname, invitee, &inv_path, &url) {
+    let hook = run_created_hook(
+        paths,
+        netname,
+        &myname,
+        invitee,
+        old_key.as_deref(),
+        &inv_path,
+        &url,
+    );
+    if let Err(e) = hook {
         let _ = fs::remove_file(&inv_path);
         return Err(e);
     }
@@ -222,6 +258,7 @@ fn run_created_hook(
     netname: Option<&str>,
     myname: &str,
     invitee: &str,
+    old_key: Option<&str>,
     inv_path: &Path,
     url: &str,
 ) -> Result<(), CmdError> {
@@ -236,6 +273,9 @@ fn run_created_hook(
         .env("INVITATION_URL", url);
     if let Some(n) = netname {
         cmd.env("NETNAME", n);
+    }
+    if let Some(k) = old_key {
+        cmd.env("REPLACE", k);
     }
     let status = cmd.status().map_err(io_err(&script))?;
     if status.success() {
@@ -718,7 +758,7 @@ mod tests {
         let confbase = cd.confbase();
         init_with_address(&paths, "alice", "myhost.example");
 
-        let r = invite(&paths, Some("testnet"), "bob", SystemTime::now()).unwrap();
+        let r = invite(&paths, Some("testnet"), "bob", false, SystemTime::now()).unwrap();
 
         // Key was freshly generated (first invite).
         assert!(r.key_is_new);
@@ -806,15 +846,9 @@ mod tests {
         .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let r = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
 
-        let inv_dir = cd.confbase().join("invitations");
-        let file = fs::read_dir(&inv_dir)
-            .unwrap()
-            .map(|e| e.unwrap().path())
-            .find(|p| p.file_name().unwrap().len() == SLUG_PART_LEN)
-            .unwrap();
-        let body = fs::read_to_string(file).unwrap();
+        let body = only_invitation(&cd);
         assert!(
             body.ends_with(&format!(
                 "Subnet = 10.0.0.7\n# bob alice {}\n",
@@ -835,7 +869,7 @@ mod tests {
         fs::write(&script, "#!/bin/sh\nexit 3\n").unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let err = invite(&paths, None, "bob", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
         assert!(err.to_string().contains("invitation-created"), "{err}");
 
         let inv_dir = cd.confbase().join("invitations");
@@ -855,13 +889,13 @@ mod tests {
         init_with_address(&paths, "alice", "myhost");
 
         // First invite: creates key + invitation file for bob.
-        let r1 = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r1 = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
         assert!(r1.key_is_new);
 
         let key_path = paths.invitation_key();
         fs::write(&key_path, "garbage, not PEM\n").unwrap();
 
-        let err = invite(&paths, None, "carol", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "carol", false, SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -886,10 +920,10 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
 
-        let r1 = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r1 = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
         assert!(r1.key_is_new);
 
-        let r2 = invite(&paths, None, "carol", SystemTime::now()).unwrap();
+        let r2 = invite(&paths, None, "carol", false, SystemTime::now()).unwrap();
         assert!(!r2.key_is_new, "second invite should reuse key");
 
         // Same key → same key_hash in both URLs.
@@ -912,7 +946,7 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
         // hosts/alice exists (init created it). Inviting alice fails.
-        let err = invite(&paths, None, "alice", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "alice", false, SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -928,8 +962,70 @@ mod tests {
         init_with_address(&paths, "alice", "myhost");
         let cd = cd.with_overlay_host("bob", "");
         let paths = cd.paths().clone();
-        let err = invite(&paths, None, "bob", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
         assert!(matches!(err, CmdError::BadInput(m) if m.contains("already exists")));
+    }
+
+    fn only_invitation(cd: &ConfDir) -> String {
+        let inv_dir = cd.confbase().join("invitations");
+        let file = fs::read_dir(&inv_dir)
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .find(|p| p.file_name().unwrap().len() == SLUG_PART_LEN)
+            .unwrap();
+        fs::read_to_string(file).unwrap()
+    }
+
+    /// `--replace` pins the node's current key on the first line and hands
+    /// it to the hook as `REPLACE`. The rest of the file is the same as for
+    /// a fresh invite.
+    #[test]
+    fn replace_pins_old_key() {
+        let cd = ConfDir::bare();
+        let paths = cd.paths().clone();
+        init_with_address(&paths, "alice", "myhost");
+        let old = b64::encode(&[7u8; 32]);
+        let cd = cd.with_overlay_host(
+            "bob",
+            &format!("Subnet = 10.0.0.7\nEd25519PublicKey = {old}\n"),
+        );
+        let paths = cd.paths().clone();
+        let script = cd.confbase().join("invitation-created");
+        fs::write(
+            &script,
+            "#!/bin/sh\necho \"# $REPLACE\" >> \"$INVITATION_FILE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+        invite(&paths, None, "bob", true, SystemTime::now()).unwrap();
+
+        let body = only_invitation(&cd);
+        assert!(
+            body.starts_with(&format!("{REPLACE_MARKER}{old}\nName = bob\n")),
+            "{body}"
+        );
+        assert!(body.ends_with(&format!("# {old}\n")), "{body}");
+    }
+
+    #[test]
+    fn replace_refusals() {
+        let cd = ConfDir::bare();
+        let paths = cd.paths().clone();
+        init_with_address(&paths, "alice", "myhost");
+        let cd = cd.with_overlay_host("rsa", "Subnet = 10.0.0.8\n");
+        let paths = cd.paths().clone();
+        for (who, want) in [
+            ("bob", "nothing to replace"),
+            ("alice", "myself"),
+            ("rsa", "no Ed25519 public key"),
+        ] {
+            let err = invite(&paths, None, who, true, SystemTime::now()).unwrap_err();
+            assert!(
+                matches!(&err, CmdError::BadInput(m) if m.contains(want)),
+                "{who}: {err}"
+            );
+        }
     }
 
     /// invite with no Address → clear error before any files created.
@@ -941,7 +1037,7 @@ mod tests {
         let confbase = cd.confbase();
         init::run(&paths, "alice").unwrap(); // no Address
 
-        let err = invite(&paths, None, "bob", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -961,7 +1057,7 @@ mod tests {
         let cd = ConfDir::bare();
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
-        let err = invite(&paths, None, "../etc", SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "../etc", false, SystemTime::now()).unwrap_err();
         assert!(matches!(err, CmdError::BadInput(_)));
     }
 
@@ -984,7 +1080,7 @@ mod tests {
         writeln!(tc, "Device = /dev/net/tun").unwrap();
         drop(tc);
 
-        let r = invite(&paths, None, "bob", SystemTime::now()).unwrap();
+        let r = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
         let slug = r.url.rsplit('/').next().unwrap();
         let (_, cookie) = tinc_crypto::invite::parse_slug(slug).unwrap();
         let sk = keypair::read_private(&paths.invitation_key()).unwrap();

--- a/crates/tinc-tools/src/cmd/join/tests.rs
+++ b/crates/tinc-tools/src/cmd/join/tests.rs
@@ -49,7 +49,7 @@ fn url_roundtrip_with_invite() {
     let inviter = ConfDir::init("alice").append_host("alice", "Address = vpn.example\n");
     let inviter = inviter.paths();
 
-    let r = invite::invite(inviter, None, "bob", SystemTime::now()).unwrap();
+    let r = invite::invite(inviter, None, "bob", false, SystemTime::now()).unwrap();
     let p = parse_url(&r.url).unwrap();
     assert_eq!(p.host, "vpn.example");
     assert_eq!(p.port, "655");
@@ -428,7 +428,7 @@ fn server_stub_recovers_file() {
     let cd = ConfDir::init("alice").append_host("alice", "Address = x\n");
     let p = cd.paths();
 
-    let r = invite::invite(p, None, "bob", SystemTime::now()).unwrap();
+    let r = invite::invite(p, None, "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&r.url).unwrap();
     let inv_key = keypair::read_private(&p.invitation_key()).unwrap();
 
@@ -454,7 +454,7 @@ fn server_stub_single_use() {
     let cd = ConfDir::init("alice").append_host("alice", "Address = x\n");
     let p = cd.paths();
 
-    let r = invite::invite(p, None, "bob", SystemTime::now()).unwrap();
+    let r = invite::invite(p, None, "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&r.url).unwrap();
     let inv_key = keypair::read_private(&p.invitation_key()).unwrap();
 
@@ -496,7 +496,8 @@ fn invite_join_roundtrip_in_process() {
         .append_conf("Mode = switch\n");
     let inviter = inviter_cd.paths();
 
-    let inv_result = invite::invite(inviter, Some("acme"), "bob", SystemTime::now()).unwrap();
+    let inv_result =
+        invite::invite(inviter, Some("acme"), "bob", false, SystemTime::now()).unwrap();
     let parsed = parse_url(&inv_result.url).unwrap();
 
     // Load invitation key. Both the server stub and the joiner's

--- a/man/tinc.8
+++ b/man/tinc.8
@@ -144,10 +144,22 @@ overwrite existing files.
 .Pq or Cm export-all
 followed by
 .Cm import .
-.It Cm invite Ar NODE
+.It Cm invite Oo Fl -replace Oc Ar NODE
 Generate an invitation URL for
 .Ar NODE
 and print it to stdout.
+With
+.Fl -replace ,
+.Ar NODE
+must already exist.
+Its current Ed25519 key is pinned in the invitation, and the device
+that joins takes over the name while the rest of the host file
+(Subnet, Address, ...) is kept.
+The join fails if the key changed in the meantime.
+Any live connection of the old device is closed.
+Both invitation scripts see the replaced key in
+.Ev REPLACE .
+tincr only.
 .It Cm join Oo Fl -identity-only Ns Oo = Ns Ar FILE Oc Oc Op Ar URL
 Join a network using an invitation URL (read from stdin if omitted).
 With


### PR DESCRIPTION
`tinc invite --replace NODE` requires NODE to exist. Its current Ed25519 key is pinned as `#replace <key>` on the first line of the invitation and handed to `invitation-created` as `REPLACE`. `dump invitations` skips the marker.
