### PR TITLE
tincd: honour replace-invitations

### DIFF
--- a/crates/tincd/src/daemon/metaconn.rs
+++ b/crates/tincd/src/daemon/metaconn.rs
@@ -15,6 +15,7 @@ use crate::dispatch::{
     record_body, send_ack,
 };
 use crate::invitation_serve::InvitePhase;
+use crate::keys;
 use crate::outgoing::ProxyConfig;
 use crate::script::ScriptEnv;
 use crate::tunnel::MTU;
@@ -926,7 +927,12 @@ impl Daemon {
                                 self.settings.invitation_lifetime,
                                 SystemTime::now(),
                             );
-                            let (contents, invited_name, used_path) = match result {
+                            let invitation_serve::Served {
+                                contents,
+                                name: invited_name,
+                                replace,
+                                used_path,
+                            } = match result {
                                 Ok(t) => t,
                                 Err(e) => {
                                     log::error!(target: "tincd::auth",
@@ -959,13 +965,14 @@ impl Daemon {
 
                             conn.invite = Some(InvitePhase::WaitingPubkey {
                                 name: invited_name.clone(),
+                                replace,
                             });
 
                             log::info!(target: "tincd::auth",
                                         "Invitation successfully sent to {invited_name} ({hostname})");
                         }
 
-                        (1, Some(InvitePhase::WaitingPubkey { name })) => {
+                        (1, Some(InvitePhase::WaitingPubkey { name, replace })) => {
                             // newline check happens inside finalize().
                             let Ok(pubkey_b64) = str::from_utf8(&bytes) else {
                                 log::error!(target: "tincd::auth",
@@ -974,10 +981,14 @@ impl Daemon {
                                 return needs_write;
                             };
 
+                            let cfg = keys::read_host_config(&self.hosts, &name);
+                            let current = keys::read_ecdsa_public_key(&cfg, &self.hosts, &name);
                             let host_path = match invitation_serve::finalize(
                                 &self.hosts,
                                 &name,
                                 pubkey_b64,
+                                replace.as_deref(),
+                                current.as_ref(),
                             ) {
                                 Ok(host_path) => {
                                     log::info!(target: "tincd::auth",
@@ -1008,7 +1019,29 @@ impl Daemon {
                                 cache.disarm();
                             }
 
-                            self.run_invitation_accepted_script(&name, &host_path, conn_addr);
+                            // A replace revokes the old key on this node,
+                            // so drop the old device's session now rather
+                            // than on its next reconnect.
+                            if replace.is_some() {
+                                let old: Vec<ConnId> = self
+                                    .conns
+                                    .iter()
+                                    .filter(|(cid, c)| *cid != id && !c.control && c.name == name)
+                                    .map(|(cid, _)| cid)
+                                    .collect();
+                                for cid in old {
+                                    log::info!(target: "tincd::auth",
+                                               "Closing connection with {name}: key replaced");
+                                    self.terminate(cid);
+                                }
+                            }
+
+                            self.run_invitation_accepted_script(
+                                &name,
+                                &host_path,
+                                replace.as_deref(),
+                                conn_addr,
+                            );
 
                             // empty type-2 = ACK; joiner closes after
                             // reading it.
@@ -1043,12 +1076,16 @@ impl Daemon {
         &self,
         node: &str,
         host_file: &Path,
+        replaced: Option<&str>,
         addr: Option<SocketAddr>,
     ) {
         let mut env = ScriptEnv::base(None, &self.name, None, Some(&self.iface), None);
         env.add("NODE", node.to_owned());
         // With HostsOverlayDirectory the file is not at hosts/$NODE.
         env.add("HOST_FILE", host_file.display().to_string());
+        if let Some(k) = replaced {
+            env.add("REPLACE", k.to_owned());
+        }
         if let Some(a) = addr {
             env.add("REMOTEADDRESS", a.ip().to_string());
             env.add("REMOTEPORT", a.port().to_string());

--- a/crates/tincd/src/daemon/setup.rs
+++ b/crates/tincd/src/daemon/setup.rs
@@ -409,8 +409,11 @@ pub(super) fn read_daemon_config(
         .ok_or_else(|| SetupError::Config("Name for tinc daemon required!".into()))?;
     let name = expand_name(name).map_err(SetupError::Config)?;
     let hosts = HostDirs::from_config(confbase, &config);
-    for n in hosts.overridden() {
-        log::warn!(target: "tincd", "hosts/{n} is overridden by {}", hosts.file(&n).display());
+    let overridden = hosts.overridden();
+    if let Some(o) = hosts.overlay()
+        && !overridden.is_empty()
+    {
+        log::warn!(target: "tincd", "{} overrides hosts/ for: {}", o.display(), overridden.join(" "));
     }
     let host = keys::read_host_config(&hosts, &name);
     if host.entries().is_empty() {

--- a/crates/tincd/src/invitation_serve.rs
+++ b/crates/tincd/src/invitation_serve.rs
@@ -19,7 +19,8 @@ use std::time::{Duration, SystemTime};
 use tinc_conf::HostDirs;
 
 use tinc_conf::read_pem;
-use tinc_crypto::invite::cookie_filename;
+use tinc_crypto::b64;
+use tinc_crypto::invite::{cookie_filename, strip_replace_marker};
 
 use std::io;
 use std::io::ErrorKind;
@@ -41,8 +42,12 @@ pub(crate) const CHUNK_SIZE: usize = 1024;
 pub(crate) enum InvitePhase {
     /// type != 0 || len != 18 → close.
     WaitingCookie,
-    /// `c->status.invitation_used = true`.
-    WaitingPubkey { name: String },
+    /// `c->status.invitation_used = true`. `replace` carries the pinned
+    /// old key when the file came from `tinc invite --replace`.
+    WaitingPubkey {
+        name: String,
+        replace: Option<String>,
+    },
     /// Post-ACK terminal state; any further record terminates the conn.
     Done,
 }
@@ -63,6 +68,11 @@ pub(crate) enum ServeError {
     /// Don't overwrite: would replace a known key.
     #[error("host config file {} already exists", .0.display())]
     HostFileExists(PathBuf),
+    /// Replace-invite whose pinned key no longer matches the host file.
+    #[error(
+        "key of {0} changed since the invitation was issued. The invitation is used up, issue a new one"
+    )]
+    KeyChanged(String),
     #[error("I/O error on {}: {err}", path.display())]
     Io {
         path: PathBuf,
@@ -124,7 +134,17 @@ fn parse_name_line(line: &str) -> Option<&str> {
     }
 }
 
-/// Type-0 (cookie) handler: returns `(file_contents, invited_name, used_path)`.
+#[derive(Debug)]
+pub(crate) struct Served {
+    /// What goes on the wire, with the replace marker stripped.
+    pub contents: Vec<u8>,
+    pub name: String,
+    /// Pinned old key (b64) from `tinc invite --replace`.
+    pub replace: Option<String>,
+    pub used_path: PathBuf,
+}
+
+/// Type-0 (cookie) handler.
 ///
 /// # Errors
 /// `NonExisting` (rename ENOENT; single use is enforced by the atomic rename),
@@ -137,7 +157,7 @@ pub(crate) fn serve_cookie(
     myname: &str,
     invitation_lifetime: Duration,
     now: SystemTime,
-) -> Result<(Vec<u8>, String, PathBuf), ServeError> {
+) -> Result<Served, ServeError> {
     // :201-207
     let filename = cookie_filename(cookie, inv_key.public_key());
     let inv_dir = confbase.join("invitations");
@@ -169,11 +189,13 @@ pub(crate) fn serve_cookie(
     }
 
     // :240-257
-    let contents = fs::read(&used_path).map_err(io_err(&used_path))?;
+    let raw = fs::read(&used_path).map_err(io_err(&used_path))?;
+    let (replace, contents) = strip_replace_marker(&raw);
+    let replace = replace.map(|k| String::from_utf8_lossy(k).into_owned());
     let first_line = contents
         .iter()
         .position(|&b| b == b'\n')
-        .map_or(&contents[..], |i| &contents[..i]);
+        .map_or(contents, |i| &contents[..i]);
     let first_line = str::from_utf8(first_line)
         .map_err(|_| ServeError::BadInvitationFile("first line not UTF-8".into()))?;
 
@@ -186,20 +208,27 @@ pub(crate) fn serve_cookie(
             ServeError::BadInvitationFile(format!("first line not `Name = X`: {first_line:?}"))
         })?;
 
-    Ok((contents, invited_name, used_path))
+    Ok(Served {
+        contents: contents.to_vec(),
+        name: invited_name,
+        replace,
+        used_path,
+    })
 }
 
-/// Type-1 handler: writes the host file, into the overlay when one is
-/// configured. Addrcache, script, unlink and the type-2 reply are
-/// daemon-side.
+/// Type-1 handler: writes the host file at `write_path`. For a
+/// replace-invite, `replace` is the pinned old key and `current` is the
+/// key the daemon currently reads for `name`.
 ///
 /// # Errors
-/// `BadPubkey` on a newline (config injection). `HostFileExists` when the
-/// name exists in either directory, so an invitee cannot replace a key.
+/// `BadPubkey` on config injection, `HostFileExists` for a fresh invite
+/// of a known name, `KeyChanged` when the pin does not match.
 pub(crate) fn finalize(
     hosts: &HostDirs,
     name: &str,
     pubkey_b64: &str,
+    replace: Option<&str>,
+    current: Option<&[u8; 32]>,
 ) -> Result<PathBuf, ServeError> {
     // Ed25519 pubkey: 32 bytes → exactly 43 chars of unpadded tinc-
     // base64. `b64::decode` rejects anything outside the union
@@ -211,13 +240,22 @@ pub(crate) fn finalize(
         return Err(ServeError::BadPubkey);
     }
 
-    if hosts.exists(name) {
-        return Err(ServeError::HostFileExists(hosts.file(name)));
-    }
     if let Some(o) = hosts.overlay() {
         fs::create_dir_all(o).map_err(io_err(o))?;
     }
     let host_path = hosts.write_path(name);
+    if let Some(pinned) = replace {
+        if current.is_none() || b64::decode(pinned).as_deref() != current.map(<[u8; 32]>::as_slice)
+        {
+            return Err(ServeError::KeyChanged(name.to_owned()));
+        }
+        let old = fs::read_to_string(hosts.file(name)).map_err(io_err(&hosts.file(name)))?;
+        write_replaced(&host_path, &old, pubkey_b64)?;
+        return Ok(host_path);
+    }
+    if hosts.exists(name) {
+        return Err(ServeError::HostFileExists(hosts.file(name)));
+    }
 
     // :128-134. C: access() then fopen("w") — TOCTOU. We: O_CREAT|O_EXCL.
     let mut f = fs::OpenOptions::new()
@@ -240,6 +278,54 @@ pub(crate) fn finalize(
     writeln!(f, "Ed25519PublicKey = {pubkey_b64}").map_err(io_err(&host_path))?;
 
     Ok(host_path)
+}
+
+/// Writes `old` with every Ed25519 public key form removed and the new
+/// key appended. Goes through tmp + rename so a reader never sees half a
+/// file.
+fn write_replaced(host_path: &Path, old: &str, pubkey_b64: &str) -> Result<(), ServeError> {
+    let mut out = String::with_capacity(old.len() + 64);
+    let mut in_pem = false;
+    for line in old.lines() {
+        if in_pem {
+            in_pem = !line.starts_with("-----END ED25519 PUBLIC KEY-----");
+            continue;
+        }
+        if line.starts_with("-----BEGIN ED25519 PUBLIC KEY-----") {
+            in_pem = true;
+            continue;
+        }
+        let key = split_var(line).map_or("", |(k, _)| k);
+        if key.eq_ignore_ascii_case("Ed25519PublicKey")
+            || key.eq_ignore_ascii_case("Ed25519PublicKeyFile")
+        {
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("Ed25519PublicKey = ");
+    out.push_str(pubkey_b64);
+    out.push('\n');
+
+    let tmp = host_path.with_extension("tmp");
+    let write = || -> io::Result<()> {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(nix::fcntl::OFlag::O_NOFOLLOW.bits())
+            .open(&tmp)?;
+        f.write_all(out.as_bytes())?;
+        fs::rename(&tmp, host_path)
+    };
+    write().map_err(|err| {
+        let _ = fs::remove_file(&tmp);
+        ServeError::Io {
+            path: host_path.to_owned(),
+            err,
+        }
+    })
 }
 
 /// Use [`CHUNK_SIZE`] for wire parity.
@@ -285,11 +371,16 @@ mod tests {
         let body = "Name = bob\nAddress = 192.0.2.1\n";
         let (tmp, cookie) = setup_invitation("roundtrip", &key, body);
 
-        let (contents, name, used_path) =
-            serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
+        let Served {
+            contents,
+            name,
+            replace,
+            used_path,
+        } = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
 
         assert_eq!(contents, body.as_bytes());
         assert_eq!(name, "bob");
+        assert!(replace.is_none());
 
         assert!(used_path.exists(), ".used file should exist");
         assert!(
@@ -322,8 +413,9 @@ mod tests {
         let key = test_key();
         let (tmp, cookie) = setup_invitation("single-use", &key, "Name = bob\n");
 
-        let (_, name, _) =
-            serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
+        let name = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now())
+            .unwrap()
+            .name;
         assert_eq!(name, "bob");
 
         // Second call: original gone → ENOENT → NonExisting.
@@ -402,7 +494,7 @@ mod tests {
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
 
         let pk = valid_pubkey_b64();
-        let path = finalize(&HostDirs::new(tmp.path(), None), "bob", &pk).unwrap();
+        let path = finalize(&HostDirs::new(tmp.path(), None), "bob", &pk, None, None).unwrap();
 
         assert_eq!(path, tmp.path().join("hosts").join("bob"));
         let written = fs::read_to_string(&path).unwrap();
@@ -415,7 +507,14 @@ mod tests {
         let tmp = TmpDir::new("fin-newline");
         fs::create_dir_all(tmp.path().join("hosts")).unwrap();
 
-        let err = finalize(&HostDirs::new(tmp.path(), None), "bob", "evil\nPort = 0").unwrap_err();
+        let err = finalize(
+            &HostDirs::new(tmp.path(), None),
+            "bob",
+            "evil\nPort = 0",
+            None,
+            None,
+        )
+        .unwrap_err();
         assert!(matches!(err, ServeError::BadPubkey));
         assert!(!tmp.path().join("hosts").join("bob").exists());
     }
@@ -431,12 +530,13 @@ mod tests {
         let bad_charset = format!("{}=", &good[..42]);
 
         for bad in [&good[..42], too_long.as_str(), bad_charset.as_str()] {
-            let err = finalize(&HostDirs::new(tmp.path(), None), "bob", bad).unwrap_err();
+            let err =
+                finalize(&HostDirs::new(tmp.path(), None), "bob", bad, None, None).unwrap_err();
             assert!(matches!(err, ServeError::BadPubkey), "{bad:?}: {err:?}");
             assert!(!tmp.path().join("hosts").join("bob").exists());
         }
 
-        finalize(&HostDirs::new(tmp.path(), None), "bob", &good).unwrap();
+        finalize(&HostDirs::new(tmp.path(), None), "bob", &good, None, None).unwrap();
     }
 
     #[test]
@@ -446,11 +546,66 @@ mod tests {
         let host = tmp.path().join("hosts").join("bob");
         fs::write(&host, "Ed25519PublicKey = original\n").unwrap();
 
-        let err =
-            finalize(&HostDirs::new(tmp.path(), None), "bob", &valid_pubkey_b64()).unwrap_err();
+        let err = finalize(
+            &HostDirs::new(tmp.path(), None),
+            "bob",
+            &valid_pubkey_b64(),
+            None,
+            None,
+        )
+        .unwrap_err();
         assert!(matches!(err, ServeError::HostFileExists(_)));
         let after = fs::read_to_string(&host).unwrap();
         assert_eq!(after, "Ed25519PublicKey = original\n");
+    }
+
+    /// The replace marker is parsed off and never reaches the invitee.
+    #[test]
+    fn serve_cookie_strips_replace_marker() {
+        let key = test_key();
+        let body = "#replace abc\nName = bob\nConnectTo = alice\n";
+        let (tmp, cookie) = setup_invitation("replace", &key, body);
+        let s = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
+        assert_eq!(s.contents, b"Name = bob\nConnectTo = alice\n");
+        assert_eq!(s.name, "bob");
+        assert_eq!(s.replace.as_deref(), Some("abc"));
+    }
+
+    /// Replace keeps everything but the key lines and writes to the
+    /// overlay. It only does so while the pinned key is still current.
+    #[test]
+    fn finalize_replace() {
+        let tmp = TmpDir::new("fin-replace");
+        let overlay = tmp.path().join("ov");
+        fs::create_dir_all(tmp.path().join("hosts")).unwrap();
+        let dirs = HostDirs::new(tmp.path(), Some(overlay.clone()));
+        let old = [1u8; 32];
+        let pin = b64::encode(&old);
+        fs::write(
+            tmp.path().join("hosts/bob"),
+            format!(
+                "# Bob <bob@example.org>\nSubnet = 10.0.0.7\nEd25519PublicKeyFile = x\n\
+                 ed25519publickey = {pin}\n-----BEGIN ED25519 PUBLIC KEY-----\nabc\n\
+                 -----END ED25519 PUBLIC KEY-----\nPort = 655\n"
+            ),
+        )
+        .unwrap();
+        let new = valid_pubkey_b64();
+
+        let err = finalize(&dirs, "bob", &new, Some(&pin), Some(&[2u8; 32])).unwrap_err();
+        assert!(matches!(err, ServeError::KeyChanged(_)));
+        let err = finalize(&dirs, "bob", &new, Some(&pin), None).unwrap_err();
+        assert!(matches!(err, ServeError::KeyChanged(_)));
+        assert!(!overlay.join("bob").exists());
+
+        let path = finalize(&dirs, "bob", &new, Some(&pin), Some(&old)).unwrap();
+        assert_eq!(path, overlay.join("bob"));
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            format!(
+                "# Bob <bob@example.org>\nSubnet = 10.0.0.7\nPort = 655\nEd25519PublicKey = {new}\n"
+            )
+        );
     }
 
     /// With an overlay, invited hosts land there and a read-only `hosts/`
@@ -463,12 +618,12 @@ mod tests {
         fs::create_dir_all(&overlay).unwrap();
         let dirs = HostDirs::new(tmp.path(), Some(overlay.clone()));
 
-        let path = finalize(&dirs, "bob", &valid_pubkey_b64()).unwrap();
+        let path = finalize(&dirs, "bob", &valid_pubkey_b64(), None, None).unwrap();
         assert_eq!(path, overlay.join("bob"));
         assert!(!tmp.path().join("hosts/bob").exists());
 
         fs::write(tmp.path().join("hosts/carol"), "").unwrap();
-        let err = finalize(&dirs, "carol", &valid_pubkey_b64()).unwrap_err();
+        let err = finalize(&dirs, "carol", &valid_pubkey_b64(), None, None).unwrap_err();
         assert!(matches!(err, ServeError::HostFileExists(_)));
         assert!(!overlay.join("carol").exists());
     }

--- a/crates/tincd/tests/two_daemons/reload.rs
+++ b/crates/tincd/tests/two_daemons/reload.rs
@@ -1,5 +1,5 @@
 use nix::sys::signal::Signal;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use super::common::node::has_subnet;
 use super::common::{
@@ -227,6 +227,82 @@ fn identity_only_join_registers_key_and_peer_connects() {
     // Not the harness key: the one the join generated.
     fs::remove_file(bob.confbase.join("ed25519_key.priv")).unwrap();
     bob.start();
+    alice.wait_for_peer("bob", true, Duration::from_secs(10));
+}
+
+/// `tinc invite --replace bob` on alice while the old bob is connected.
+/// A new device joins under bob's name. Alice keeps bob's Subnet and
+/// swaps the key in the overlay, leaving `hosts/` untouched. The old bob
+/// is kicked and stays out, the new key gets in.
+#[test]
+fn replace_invite_rekeys_node_and_drops_old_device() {
+    let tmp = tmp!("replace");
+    let mut alice =
+        Node::new(tmp.path(), "alice", 0xAA).with_conf("HostsOverlayDirectory = hosts.local\n");
+    let mut bob = Node::new(tmp.path(), "bob", 0xBB);
+    bob.start_dialing(&mut alice);
+    let hosts_bob = alice.confbase.join("hosts/bob");
+    fs::write(
+        &hosts_bob,
+        fs::read_to_string(&hosts_bob).unwrap() + "Subnet = 10.0.0.7/32\n",
+    )
+    .unwrap();
+    let hook = alice.confbase.join("invitation-accepted");
+    let hook_out = alice.confbase.join("hook.out");
+    fs::write(
+        &hook,
+        format!("#!/bin/sh\necho \"$REPLACE\" > '{}'\n", hook_out.display()),
+    )
+    .unwrap();
+    fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Real `tinc invite --replace`, which needs alice's Address for the URL.
+    let hosts_alice = alice.confbase.join("hosts/alice");
+    fs::write(
+        &hosts_alice,
+        fs::read_to_string(&hosts_alice).unwrap()
+            + &format!("Address = 127.0.0.1 {}\n", alice.port),
+    )
+    .unwrap();
+    let alice_paths = cli_paths(alice.confbase.clone());
+    let err = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", false, SystemTime::now())
+        .unwrap_err();
+    assert!(err.to_string().contains("already exists"), "{err}");
+    let url = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", true, SystemTime::now())
+        .unwrap()
+        .url;
+    assert_eq!(alice.ctl().reload(), 0);
+
+    let key = tmp.path().join("newbob.priv");
+    if let Err(err) = tinc_tools::cmd::join::join(&url, &Mode::IdentityOnly(Some(key.clone()))) {
+        panic!("join: {err:?}\nalice:\n{}", alice.stop());
+    }
+
+    let old_b64 = tinc_crypto::b64::encode(&bob.pubkey());
+    let overlay_bob = alice.confbase.join("hosts.local/bob");
+    assert!(wait_for_file(&overlay_bob));
+    let new_host = fs::read_to_string(&overlay_bob).unwrap();
+    assert!(
+        new_host.starts_with("Subnet = 10.0.0.7/32\nEd25519PublicKey = "),
+        "{new_host}"
+    );
+    assert!(!new_host.contains(&old_b64));
+    assert!(fs::read_to_string(&hosts_bob).unwrap().contains(&old_b64));
+    assert!(wait_for_file(&hook_out));
+    assert_eq!(fs::read_to_string(&hook_out).unwrap().trim(), old_b64);
+
+    // Old bob was kicked and stays out when it retries with the old key.
+    alice.wait_for_peer("bob", false, Duration::from_secs(10));
+    thread::sleep(Duration::from_millis(1500));
+    assert!(!alice.has_active_peer("bob"), "old key got back in");
+    bob.stop();
+
+    // New device with the joined key connects as bob.
+    let mut newbob = Node::new(tmp.path(), "bob", 0xBB)
+        .with_conf(&format!("Ed25519PrivateKeyFile = {}\n", key.display()));
+    newbob.write_config_multi(&[&alice], &[&alice]);
+    fs::remove_file(newbob.confbase.join("ed25519_key.priv")).unwrap();
+    newbob.start();
     alice.wait_for_peer("bob", true, Duration::from_secs(10));
 }
 

--- a/docs/COMPAT.md
+++ b/docs/COMPAT.md
@@ -67,7 +67,12 @@ participate.
   unit file doesn't need `-d` flags.
 - **`HostsOverlayDirectory` config key.** Second host directory for
   deployments where `hosts/` is read-only. Invited nodes are written
-  there and `invitation-accepted` gets the path in `HOST_FILE`.
+  there, override `hosts/`, and `invitation-accepted` gets the path in
+  `HOST_FILE`.
+- **`tinc invite --replace NODE`.** Re-keys an existing node through an
+  invitation (new phone, lost key). The invitation file starts with
+  `#replace <oldkey>`. A C tincd serving such a file refuses the join
+  with "host file exists", so mixed setups fail safe.
 - **`SPTPSCipher` host key.** Selects AES-256-GCM instead of
   ChaCha20-Poly1305 for the SPTPS record AEAD on a per-edge basis.
   On AES-NI/PMULL hardware this roughly doubles tunnel throughput.


### PR DESCRIPTION
tincd strips the `#replace` marker before sending and checks the pin against the key it currently reads for NODE. It then rewrites the host file with only the key swapped (tmp+rename, overlay if set), closes the old device's connection and passes `REPLACE` to `invitation-accepted`.
