### PR TITLE
nixos: make invitations/ writable for the service user

### DIFF
--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -109,7 +109,12 @@ Since `hosts/` lives in the store,
 the module sets `HostsOverlayDirectory = /var/lib/tincr/<net>/hosts`:
 nodes that accept an invitation are written there and override the
 deployed copy until removed. Prune entries that match `hosts` after a
-deploy.
+deploy. `/etc/tinc/<net>/invitations` is a symlink into the same
+state directory, so invitations are issued as the service user:
+
+```console
+$ sudo -u tincr tinc -n mesh --pidfile /run/tincr/mesh.pid invite phone
+```
 
 Set `socketActivation = false` to start the daemon at boot
 (`multi-user.target`) instead of on the first inbound connection.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -449,6 +449,15 @@ in
 
       environment.etc = mkMerge (mapAttrsToList etcForNet enabledNets);
 
+      # `tinc invite` and tincd use confbase/invitations, which is under
+      # read-only /etc here. Keep the data in the state dir.
+      systemd.tmpfiles.rules = flatten (
+        mapAttrsToList (n: _: [
+          "d /var/lib/tincr/${n}/invitations 0700 ${serviceUser} ${serviceUser} -"
+          "L /etc/tinc/${n}/invitations - - - - /var/lib/tincr/${n}/invitations"
+        ]) enabledNets
+      );
+
       networking.useNetworkd = mkDefault true;
       systemd.network = {
         netdevs = mapAttrs' (n: net: nameValuePair "40-tincr-${n}" (mkNetdev n net)) enabledNets;

--- a/nix/nixos-test-tincr.nix
+++ b/nix/nixos-test-tincr.nix
@@ -12,6 +12,7 @@ let
 
   hosts = {
     alpha = ''
+      Address = 192.168.1.1
       Subnet = 10.21.0.1/32
       Ed25519PublicKey = ${keys.alpha.ed25519Public}
     '';
@@ -162,8 +163,16 @@ testers.runNixOSTest {
         alpha.wait_until_succeeds("systemctl is-active tincr-mesh.service", timeout=30)
         alpha.wait_until_succeeds("ping -c1 -W2 10.21.0.2", timeout=30)
 
+    with subtest("tinc invite works as the service user"):
+        url = alpha.succeed(
+            "runuser -u tincr -- tinc -n mesh --pidfile /run/tincr/mesh.pid invite gamma"
+        ).strip()
+        assert len(url.rsplit("/", 1)[1]) == 48, url
+        alpha.succeed("runuser -u tincr -- test -O /var/lib/tincr/mesh/invitations/ed25519_key.priv")
+
     with subtest("clean stop"):
-        alpha.systemctl("stop tincr-mesh.service")
+        # alpha has an Address now, so beta would re-trigger the socket.
+        alpha.systemctl("stop tincr-mesh.socket tincr-mesh.service")
         alpha.wait_until_succeeds(
             "systemctl show -p ActiveState tincr-mesh.service "
             "| grep -x ActiveState=inactive",


### PR DESCRIPTION
On module-managed hosts `tinc invite` failed with EACCES on /etc/tinc/<net>/invitations. tmpfiles now links it to /var/lib/tincr/<net>/invitations; NixOS test issues an invitation as user tincr.
