### PR TITLE
tinc invite: add -e KEY=VAL for the invitation scripts

### DIFF
--- a/crates/tinc-crypto/src/invite.rs
+++ b/crates/tinc-crypto/src/invite.rs
@@ -50,6 +50,7 @@
 //! other two reject silently. Hence: KAT-tested via `kat/gen_kat.c`.
 
 use sha2::{Digest, Sha512};
+use std::fmt;
 use zeroize::Zeroize;
 
 use crate::b64;
@@ -70,19 +71,82 @@ pub const SLUG_PART_LEN: usize = 24;
 /// Full slug length: `b64(key_hash) || b64(cookie)`.
 pub const SLUG_LEN: usize = 2 * SLUG_PART_LEN;
 
-/// First line of a replace-invitation: `#replace <old-b64-pubkey>`. tincr
-/// only. The daemon strips it before sending, so `tinc join` never sees it.
+/// Header line pinning the key a replace-invitation swaps out. tincr
+/// only. The daemon strips headers before sending, so `tinc join`
+/// never sees them.
 pub const REPLACE_MARKER: &str = "#replace ";
+/// Header line carrying `KEY=VAL` for the invitation hooks.
+pub const ENV_MARKER: &str = "#env ";
 
-/// Split an optional replace marker off an invitation file. Returns the
-/// pinned old key (still b64) and the remainder starting at `Name =`.
+/// Env names the hooks get from tinc itself. A header must not spoof them.
+pub const RESERVED_ENV: &[&str] = &[
+    "NAME",
+    "NODE",
+    "NETNAME",
+    "INVITATION_FILE",
+    "INVITATION_URL",
+    "HOST_FILE",
+    "REPLACE",
+    "REMOTEADDRESS",
+    "REMOTEPORT",
+    "DEVICE",
+    "INTERFACE",
+    "DEBUG",
+];
+
+/// `KEY` for `-e KEY=VAL`: shell-safe and not one tinc sets itself.
 #[must_use]
-pub fn strip_replace_marker(contents: &[u8]) -> (Option<&[u8]>, &[u8]) {
-    let Some(rest) = contents.strip_prefix(REPLACE_MARKER.as_bytes()) else {
-        return (None, contents);
-    };
-    let nl = rest.iter().position(|&b| b == b'\n').unwrap_or(rest.len());
-    (Some(&rest[..nl]), rest.get(nl + 1..).unwrap_or_default())
+pub fn valid_env_key(k: &str) -> bool {
+    let mut b = k.bytes();
+    b.next()
+        .is_some_and(|c| c.is_ascii_uppercase() || c == b'_')
+        && b.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == b'_')
+        && !RESERVED_ENV.contains(&k)
+}
+
+/// Leading `#` lines of an invitation file, parsed.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Headers {
+    /// Pinned old key (b64) from `#replace`.
+    pub replace: Option<String>,
+    /// `#env KEY=VAL` pairs, in file order, keys validated.
+    pub env: Vec<(String, String)>,
+}
+
+impl fmt::Display for Headers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(k) = &self.replace {
+            writeln!(f, "{REPLACE_MARKER}{k}")?;
+        }
+        for (k, v) in &self.env {
+            writeln!(f, "{ENV_MARKER}{k}={v}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Split the `#` header block off an invitation file. Returns the parsed
+/// headers and the remainder starting at `Name =`.
+#[must_use]
+pub fn strip_headers(mut contents: &[u8]) -> (Headers, &[u8]) {
+    let mut h = Headers::default();
+    while contents.first() == Some(&b'#') {
+        let nl = contents
+            .iter()
+            .position(|&b| b == b'\n')
+            .unwrap_or(contents.len());
+        let line = String::from_utf8_lossy(&contents[..nl]);
+        if let Some(k) = line.strip_prefix(REPLACE_MARKER) {
+            h.replace = Some(k.to_owned());
+        } else if let Some(kv) = line.strip_prefix(ENV_MARKER)
+            && let Some((k, v)) = kv.split_once('=')
+            && valid_env_key(k)
+        {
+            h.env.push((k.to_owned(), v.to_owned()));
+        }
+        contents = contents.get(nl + 1..).unwrap_or_default();
+    }
+    (h, contents)
 }
 
 // Compile-time witness that 18 → 24 is the encoding length we claimed.
@@ -213,19 +277,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn replace_marker() {
-        assert_eq!(
-            strip_replace_marker(b"Name = a\n"),
-            (None, &b"Name = a\n"[..])
+    fn headers() {
+        let (h, rest) = strip_headers(b"Name = a\n");
+        assert_eq!((h, rest), (Headers::default(), &b"Name = a\n"[..]));
+
+        let (h, rest) = strip_headers(
+            b"#replace abc\n#env KARTEI_NS=mic92\n#env X=a=b\n# note\n#env NODE=x\n#env bad key=1\nName = a\n",
         );
+        assert_eq!(h.replace.as_deref(), Some("abc"));
         assert_eq!(
-            strip_replace_marker(b"#replace abc\nName = a\n"),
-            (Some(&b"abc"[..]), &b"Name = a\n"[..])
+            h.env,
+            [
+                ("KARTEI_NS".into(), "mic92".into()),
+                ("X".into(), "a=b".into())
+            ]
         );
-        assert_eq!(
-            strip_replace_marker(b"#replace abc"),
-            (Some(&b"abc"[..]), &b""[..])
-        );
+        assert_eq!(rest, b"Name = a\n");
+
+        assert_eq!(strip_headers(b"#replace abc").1, b"");
+        assert_eq!(strip_headers(h.to_string().as_bytes()).0, h);
+    }
+
+    #[test]
+    fn env_key() {
+        assert!(valid_env_key("KARTEI_NS"));
+        assert!(valid_env_key("_X1"));
+        for k in ["", "ns", "1A", "A-B", "A B", "NODE", "REPLACE", "HOST_FILE"] {
+            assert!(!valid_env_key(k), "{k}");
+        }
     }
 
     /// `key_hash(pk) == fingerprint_hash(fingerprint(pk))`. The KAT

--- a/crates/tinc-tools/src/bin/tinc.rs
+++ b/crates/tinc-tools/src/bin/tinc.rs
@@ -190,7 +190,7 @@ const COMMANDS: &[CmdEntry] = &[
         // unredeemable until manual restart.
         needs_daemon: true,
         run: Run::Any(cmd_invite),
-        help: "invite [--replace] NODE  Generate an invitation for NODE.\n    --replace - let a new device take over NODE's name, replacing its key",
+        help: "invite [OPTIONS] NODE  Generate an invitation for NODE.\n    -e KEY=VAL - pass KEY=VAL to the invitation hooks\n    --replace - let a new device take over NODE's name, replacing its key",
     },
     CmdEntry {
         name: "join",
@@ -481,12 +481,25 @@ fn cmd_fsck(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError>
 /// `tinc invite alice | mail alice@example` works). Warnings to
 /// stderr.
 fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError> {
-    let (replace, args) = match args.split_first() {
-        Some((a, rest)) if a == "--replace" => (true, rest),
-        _ => (false, args),
-    };
-    let [invitee] = args else {
-        return Err(if args.is_empty() {
+    let mut replace = false;
+    let mut env = Vec::new();
+    let mut rest = Vec::new();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--replace" => replace = true,
+            "-e" => {
+                let kv = it.next().ok_or(CmdError::MissingArg("-e KEY=VAL"))?;
+                let (k, v) = kv
+                    .split_once('=')
+                    .ok_or_else(|| CmdError::BadInput(format!("-e {kv}: expected KEY=VAL")))?;
+                env.push((k.to_owned(), v.to_owned()));
+            }
+            _ => rest.push(a),
+        }
+    }
+    let [invitee] = rest[..] else {
+        return Err(if rest.is_empty() {
             CmdError::MissingArg("node name")
         } else {
             CmdError::TooManyArgs
@@ -498,6 +511,7 @@ fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdErro
         g.netname.as_deref(),
         invitee,
         replace,
+        &env,
         SystemTime::now(),
     )?;
 

--- a/crates/tinc-tools/src/cmd/dump.rs
+++ b/crates/tinc-tools/src/cmd/dump.rs
@@ -34,7 +34,7 @@ use crate::names::{Paths, check_id};
 // Re-exported so existing `cmd::dump::{NodeRow,…}` paths keep working.
 pub use crate::ctl::rows::{ConnRow, EdgeRow, NodeRow, StatusBit, SubnetRow, strip_weight};
 use std::io::ErrorKind;
-use tinc_crypto::invite::{REPLACE_MARKER, SLUG_PART_LEN};
+use tinc_crypto::invite::SLUG_PART_LEN;
 
 /// Which `dump` sub-verb.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -182,10 +182,10 @@ pub fn dump_invitations(paths: &Paths) -> Result<Vec<InviteRow>, CmdError> {
         if rd.read_line(&mut first).is_err() || first.is_empty() {
             continue;
         }
-        if first.starts_with(REPLACE_MARKER) {
+        while first.starts_with('#') {
             first.clear();
-            if rd.read_line(&mut first).is_err() {
-                continue;
+            if rd.read_line(&mut first).is_err() || first.is_empty() {
+                break;
             }
         }
 

--- a/crates/tinc-tools/src/cmd/dump/tests.rs
+++ b/crates/tinc-tools/src/cmd/dump/tests.rs
@@ -662,7 +662,7 @@ fn inv_roundtrip_with_invite() {
 
     // `now` is parameterized for sweep_expired tests; pass real time.
     let now = SystemTime::now();
-    let result = invite::invite(&paths, None, "bob", false, now).unwrap();
+    let result = invite::invite(&paths, None, "bob", false, &[], now).unwrap();
     // Only the written file matters here, not the returned URL.
     let _ = result;
 

--- a/crates/tinc-tools/src/cmd/invite.rs
+++ b/crates/tinc-tools/src/cmd/invite.rs
@@ -55,7 +55,9 @@ use std::time::{Duration, SystemTime};
 use rand_core::Rng;
 use tinc_conf::Config;
 use tinc_crypto::b64;
-use tinc_crypto::invite::{COOKIE_LEN, REPLACE_MARKER, SLUG_PART_LEN, build_slug, cookie_filename};
+use tinc_crypto::invite::{
+    COOKIE_LEN, Headers, SLUG_PART_LEN, build_slug, cookie_filename, valid_env_key,
+};
 use tinc_crypto::os_rng;
 use tinc_crypto::sign::SigningKey;
 use zeroize::Zeroizing;
@@ -104,10 +106,9 @@ pub struct InviteResult {
     pub key_is_new: bool,
 }
 
-/// `tinc invite [--replace] NODENAME`. `now` is injectable for tests. With
-/// `replace`, NODENAME must already exist. Its current Ed25519 key is
-/// pinned in the invitation so the daemon swaps exactly that key at join
-/// time.
+/// `tinc invite [-e KEY=VAL] [--replace] NODENAME`. With `replace`,
+/// NODENAME must exist and its current key is pinned so the daemon swaps
+/// exactly that key. `env` is stored in the invitation for both hooks.
 ///
 /// # Errors
 /// `BadInput` (invalid or taken name, no `Address` configured) or `Io`.
@@ -116,12 +117,18 @@ pub fn invite(
     netname: Option<&str>,
     invitee: &str,
     replace: bool,
+    env: &[(String, String)],
     now: SystemTime,
 ) -> Result<InviteResult, CmdError> {
     if !check_id(invitee) {
         return Err(CmdError::BadInput(format!(
             "Invalid name for node: {invitee}"
         )));
+    }
+    for (k, v) in env {
+        if !valid_env_key(k) || v.contains('\n') {
+            return Err(CmdError::BadInput(format!("Invalid -e {k}=...")));
+        }
     }
 
     // Needed for the `ConnectTo` line and the host config dump.
@@ -222,10 +229,12 @@ pub fn invite(
     // Write the invitation file, O_EXCL 0600 (an 18-byte random cookie can't
     // collide, so EEXIST is a real problem). Built as one string and written once:
     // testable builder, no partial writes.
-    let mut body = build_invitation_file(paths, netname, invitee, &myname, &address)?;
-    if let Some(k) = &old_key {
-        body.insert_str(0, &format!("{REPLACE_MARKER}{k}\n"));
-    }
+    let headers = Headers {
+        replace: old_key,
+        env: env.to_vec(),
+    };
+    let body =
+        headers.to_string() + &build_invitation_file(paths, netname, invitee, &myname, &address)?;
     write_invitation_file(&inv_path, &body)?;
 
     // Build the URL
@@ -233,15 +242,15 @@ pub fn invite(
     let slug = Zeroizing::new(build_slug(pubkey, &cookie));
     let url = Zeroizing::new(format!("{address}/{}", *slug));
 
-    let hook = run_created_hook(
-        paths,
-        netname,
-        &myname,
-        invitee,
-        old_key.as_deref(),
-        &inv_path,
-        &url,
-    );
+    let mut hook_env: Vec<(&str, &str)> = vec![
+        ("NAME", &myname),
+        ("NODE", invitee),
+        ("INVITATION_URL", &url),
+    ];
+    hook_env.extend(netname.map(|n| ("NETNAME", n)));
+    hook_env.extend(headers.replace.as_deref().map(|k| ("REPLACE", k)));
+    hook_env.extend(env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+    let hook = run_created_hook(paths, &inv_path, &hook_env);
     if let Err(e) = hook {
         let _ = fs::remove_file(&inv_path);
         return Err(e);
@@ -253,30 +262,14 @@ pub fn invite(
 /// Run `confbase/invitation-created` with the upstream env contract. The
 /// hook may edit `INVITATION_FILE`, and whatever it leaves there is what
 /// the invitee receives.
-fn run_created_hook(
-    paths: &Paths,
-    netname: Option<&str>,
-    myname: &str,
-    invitee: &str,
-    old_key: Option<&str>,
-    inv_path: &Path,
-    url: &str,
-) -> Result<(), CmdError> {
+fn run_created_hook(paths: &Paths, inv_path: &Path, env: &[(&str, &str)]) -> Result<(), CmdError> {
     let script = paths.confbase.join("invitation-created");
     if !script.exists() {
         return Ok(());
     }
     let mut cmd = Command::new(&script);
-    cmd.env("NAME", myname)
-        .env("NODE", invitee)
-        .env("INVITATION_FILE", inv_path)
-        .env("INVITATION_URL", url);
-    if let Some(n) = netname {
-        cmd.env("NETNAME", n);
-    }
-    if let Some(k) = old_key {
-        cmd.env("REPLACE", k);
-    }
+    cmd.env("INVITATION_FILE", inv_path)
+        .envs(env.iter().copied());
     let status = cmd.status().map_err(io_err(&script))?;
     if status.success() {
         Ok(())
@@ -758,7 +751,15 @@ mod tests {
         let confbase = cd.confbase();
         init_with_address(&paths, "alice", "myhost.example");
 
-        let r = invite(&paths, Some("testnet"), "bob", false, SystemTime::now()).unwrap();
+        let r = invite(
+            &paths,
+            Some("testnet"),
+            "bob",
+            false,
+            &[],
+            SystemTime::now(),
+        )
+        .unwrap();
 
         // Key was freshly generated (first invite).
         assert!(r.key_is_new);
@@ -846,7 +847,7 @@ mod tests {
         .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let r = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
+        let r = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap();
 
         let body = only_invitation(&cd);
         assert!(
@@ -869,7 +870,7 @@ mod tests {
         fs::write(&script, "#!/bin/sh\nexit 3\n").unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap_err();
         assert!(err.to_string().contains("invitation-created"), "{err}");
 
         let inv_dir = cd.confbase().join("invitations");
@@ -889,13 +890,13 @@ mod tests {
         init_with_address(&paths, "alice", "myhost");
 
         // First invite: creates key + invitation file for bob.
-        let r1 = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
+        let r1 = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap();
         assert!(r1.key_is_new);
 
         let key_path = paths.invitation_key();
         fs::write(&key_path, "garbage, not PEM\n").unwrap();
 
-        let err = invite(&paths, None, "carol", false, SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "carol", false, &[], SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -920,10 +921,10 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
 
-        let r1 = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
+        let r1 = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap();
         assert!(r1.key_is_new);
 
-        let r2 = invite(&paths, None, "carol", false, SystemTime::now()).unwrap();
+        let r2 = invite(&paths, None, "carol", false, &[], SystemTime::now()).unwrap();
         assert!(!r2.key_is_new, "second invite should reuse key");
 
         // Same key → same key_hash in both URLs.
@@ -946,7 +947,7 @@ mod tests {
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
         // hosts/alice exists (init created it). Inviting alice fails.
-        let err = invite(&paths, None, "alice", false, SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "alice", false, &[], SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -962,7 +963,7 @@ mod tests {
         init_with_address(&paths, "alice", "myhost");
         let cd = cd.with_overlay_host("bob", "");
         let paths = cd.paths().clone();
-        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap_err();
         assert!(matches!(err, CmdError::BadInput(m) if m.contains("already exists")));
     }
 
@@ -993,19 +994,28 @@ mod tests {
         let script = cd.confbase().join("invitation-created");
         fs::write(
             &script,
-            "#!/bin/sh\necho \"# $REPLACE\" >> \"$INVITATION_FILE\"\n",
+            "#!/bin/sh\necho \"# $REPLACE $KARTEI_NS\" >> \"$INVITATION_FILE\"\n",
         )
         .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
-        invite(&paths, None, "bob", true, SystemTime::now()).unwrap();
+        let env = [("KARTEI_NS".to_owned(), "mic92".to_owned())];
+        invite(&paths, None, "bob", true, &env, SystemTime::now()).unwrap();
 
         let body = only_invitation(&cd);
         assert!(
-            body.starts_with(&format!("{REPLACE_MARKER}{old}\nName = bob\n")),
+            body.starts_with(&format!(
+                "#replace {old}\n#env KARTEI_NS=mic92\nName = bob\n"
+            )),
             "{body}"
         );
-        assert!(body.ends_with(&format!("# {old}\n")), "{body}");
+        assert!(body.ends_with(&format!("# {old} mic92\n")), "{body}");
+
+        for (k, v) in [("NODE", "x"), ("lower", "x"), ("OK", "a\nb")] {
+            let env = [(k.to_owned(), v.to_owned())];
+            let err = invite(&paths, None, "carol", false, &env, SystemTime::now()).unwrap_err();
+            assert!(matches!(err, CmdError::BadInput(_)), "{k}: {err}");
+        }
     }
 
     #[test]
@@ -1020,7 +1030,7 @@ mod tests {
             ("alice", "myself"),
             ("rsa", "no Ed25519 public key"),
         ] {
-            let err = invite(&paths, None, who, true, SystemTime::now()).unwrap_err();
+            let err = invite(&paths, None, who, true, &[], SystemTime::now()).unwrap_err();
             assert!(
                 matches!(&err, CmdError::BadInput(m) if m.contains(want)),
                 "{who}: {err}"
@@ -1037,7 +1047,7 @@ mod tests {
         let confbase = cd.confbase();
         init::run(&paths, "alice").unwrap(); // no Address
 
-        let err = invite(&paths, None, "bob", false, SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap_err();
         let CmdError::BadInput(msg) = err else {
             panic!("wrong variant: {err:?}")
         };
@@ -1057,7 +1067,7 @@ mod tests {
         let cd = ConfDir::bare();
         let paths = cd.paths().clone();
         init_with_address(&paths, "alice", "myhost");
-        let err = invite(&paths, None, "../etc", false, SystemTime::now()).unwrap_err();
+        let err = invite(&paths, None, "../etc", false, &[], SystemTime::now()).unwrap_err();
         assert!(matches!(err, CmdError::BadInput(_)));
     }
 
@@ -1080,7 +1090,7 @@ mod tests {
         writeln!(tc, "Device = /dev/net/tun").unwrap();
         drop(tc);
 
-        let r = invite(&paths, None, "bob", false, SystemTime::now()).unwrap();
+        let r = invite(&paths, None, "bob", false, &[], SystemTime::now()).unwrap();
         let slug = r.url.rsplit('/').next().unwrap();
         let (_, cookie) = tinc_crypto::invite::parse_slug(slug).unwrap();
         let sk = keypair::read_private(&paths.invitation_key()).unwrap();

--- a/crates/tinc-tools/src/cmd/join/tests.rs
+++ b/crates/tinc-tools/src/cmd/join/tests.rs
@@ -49,7 +49,7 @@ fn url_roundtrip_with_invite() {
     let inviter = ConfDir::init("alice").append_host("alice", "Address = vpn.example\n");
     let inviter = inviter.paths();
 
-    let r = invite::invite(inviter, None, "bob", false, SystemTime::now()).unwrap();
+    let r = invite::invite(inviter, None, "bob", false, &[], SystemTime::now()).unwrap();
     let p = parse_url(&r.url).unwrap();
     assert_eq!(p.host, "vpn.example");
     assert_eq!(p.port, "655");
@@ -428,7 +428,7 @@ fn server_stub_recovers_file() {
     let cd = ConfDir::init("alice").append_host("alice", "Address = x\n");
     let p = cd.paths();
 
-    let r = invite::invite(p, None, "bob", false, SystemTime::now()).unwrap();
+    let r = invite::invite(p, None, "bob", false, &[], SystemTime::now()).unwrap();
     let parsed = parse_url(&r.url).unwrap();
     let inv_key = keypair::read_private(&p.invitation_key()).unwrap();
 
@@ -454,7 +454,7 @@ fn server_stub_single_use() {
     let cd = ConfDir::init("alice").append_host("alice", "Address = x\n");
     let p = cd.paths();
 
-    let r = invite::invite(p, None, "bob", false, SystemTime::now()).unwrap();
+    let r = invite::invite(p, None, "bob", false, &[], SystemTime::now()).unwrap();
     let parsed = parse_url(&r.url).unwrap();
     let inv_key = keypair::read_private(&p.invitation_key()).unwrap();
 
@@ -497,7 +497,7 @@ fn invite_join_roundtrip_in_process() {
     let inviter = inviter_cd.paths();
 
     let inv_result =
-        invite::invite(inviter, Some("acme"), "bob", false, SystemTime::now()).unwrap();
+        invite::invite(inviter, Some("acme"), "bob", false, &[], SystemTime::now()).unwrap();
     let parsed = parse_url(&inv_result.url).unwrap();
 
     // Load invitation key. Both the server stub and the joiner's

--- a/crates/tincd/src/daemon/metaconn.rs
+++ b/crates/tincd/src/daemon/metaconn.rs
@@ -39,6 +39,7 @@ use crate::tcp_tunnel;
 use std::fs;
 use std::str;
 use std::time::Instant;
+use tinc_crypto::invite::Headers;
 use tinc_crypto::os_rng;
 use tinc_proto::Request;
 use tinc_sptps::Output;
@@ -930,7 +931,7 @@ impl Daemon {
                             let invitation_serve::Served {
                                 contents,
                                 name: invited_name,
-                                replace,
+                                headers,
                                 used_path,
                             } = match result {
                                 Ok(t) => t,
@@ -965,14 +966,15 @@ impl Daemon {
 
                             conn.invite = Some(InvitePhase::WaitingPubkey {
                                 name: invited_name.clone(),
-                                replace,
+                                headers,
                             });
 
                             log::info!(target: "tincd::auth",
                                         "Invitation successfully sent to {invited_name} ({hostname})");
                         }
 
-                        (1, Some(InvitePhase::WaitingPubkey { name, replace })) => {
+                        (1, Some(InvitePhase::WaitingPubkey { name, headers })) => {
+                            let Headers { replace, env } = headers;
                             // newline check happens inside finalize().
                             let Ok(pubkey_b64) = str::from_utf8(&bytes) else {
                                 log::error!(target: "tincd::auth",
@@ -1040,6 +1042,7 @@ impl Daemon {
                                 &name,
                                 &host_path,
                                 replace.as_deref(),
+                                env,
                                 conn_addr,
                             );
 
@@ -1077,6 +1080,7 @@ impl Daemon {
         node: &str,
         host_file: &Path,
         replaced: Option<&str>,
+        extra: Vec<(String, String)>,
         addr: Option<SocketAddr>,
     ) {
         let mut env = ScriptEnv::base(None, &self.name, None, Some(&self.iface), None);
@@ -1085,6 +1089,9 @@ impl Daemon {
         env.add("HOST_FILE", host_file.display().to_string());
         if let Some(k) = replaced {
             env.add("REPLACE", k.to_owned());
+        }
+        for (k, v) in extra {
+            env.add(k, v);
         }
         if let Some(a) = addr {
             env.add("REMOTEADDRESS", a.ip().to_string());

--- a/crates/tincd/src/invitation_serve.rs
+++ b/crates/tincd/src/invitation_serve.rs
@@ -20,7 +20,7 @@ use tinc_conf::HostDirs;
 
 use tinc_conf::read_pem;
 use tinc_crypto::b64;
-use tinc_crypto::invite::{cookie_filename, strip_replace_marker};
+use tinc_crypto::invite::{Headers, cookie_filename, strip_headers};
 
 use std::io;
 use std::io::ErrorKind;
@@ -42,12 +42,8 @@ pub(crate) const CHUNK_SIZE: usize = 1024;
 pub(crate) enum InvitePhase {
     /// type != 0 || len != 18 → close.
     WaitingCookie,
-    /// `c->status.invitation_used = true`. `replace` carries the pinned
-    /// old key when the file came from `tinc invite --replace`.
-    WaitingPubkey {
-        name: String,
-        replace: Option<String>,
-    },
+    /// `c->status.invitation_used = true`.
+    WaitingPubkey { name: String, headers: Headers },
     /// Post-ACK terminal state; any further record terminates the conn.
     Done,
 }
@@ -136,11 +132,10 @@ fn parse_name_line(line: &str) -> Option<&str> {
 
 #[derive(Debug)]
 pub(crate) struct Served {
-    /// What goes on the wire, with the replace marker stripped.
+    /// What goes on the wire, headers stripped.
     pub contents: Vec<u8>,
     pub name: String,
-    /// Pinned old key (b64) from `tinc invite --replace`.
-    pub replace: Option<String>,
+    pub headers: Headers,
     pub used_path: PathBuf,
 }
 
@@ -190,8 +185,7 @@ pub(crate) fn serve_cookie(
 
     // :240-257
     let raw = fs::read(&used_path).map_err(io_err(&used_path))?;
-    let (replace, contents) = strip_replace_marker(&raw);
-    let replace = replace.map(|k| String::from_utf8_lossy(k).into_owned());
+    let (headers, contents) = strip_headers(&raw);
     let first_line = contents
         .iter()
         .position(|&b| b == b'\n')
@@ -211,7 +205,7 @@ pub(crate) fn serve_cookie(
     Ok(Served {
         contents: contents.to_vec(),
         name: invited_name,
-        replace,
+        headers,
         used_path,
     })
 }
@@ -374,13 +368,13 @@ mod tests {
         let Served {
             contents,
             name,
-            replace,
+            headers,
             used_path,
         } = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
 
         assert_eq!(contents, body.as_bytes());
         assert_eq!(name, "bob");
-        assert!(replace.is_none());
+        assert_eq!(headers, Headers::default());
 
         assert!(used_path.exists(), ".used file should exist");
         assert!(
@@ -559,16 +553,17 @@ mod tests {
         assert_eq!(after, "Ed25519PublicKey = original\n");
     }
 
-    /// The replace marker is parsed off and never reaches the invitee.
+    /// Headers are parsed off and never reach the invitee.
     #[test]
-    fn serve_cookie_strips_replace_marker() {
+    fn serve_cookie_strips_headers() {
         let key = test_key();
-        let body = "#replace abc\nName = bob\nConnectTo = alice\n";
+        let body = "#replace abc\n#env KARTEI_NS=mic92\nName = bob\nConnectTo = alice\n";
         let (tmp, cookie) = setup_invitation("replace", &key, body);
         let s = serve_cookie(tmp.path(), &key, &cookie, "alice", WEEK, SystemTime::now()).unwrap();
         assert_eq!(s.contents, b"Name = bob\nConnectTo = alice\n");
         assert_eq!(s.name, "bob");
-        assert_eq!(s.replace.as_deref(), Some("abc"));
+        assert_eq!(s.headers.replace.as_deref(), Some("abc"));
+        assert_eq!(s.headers.env, [("KARTEI_NS".into(), "mic92".into())]);
     }
 
     /// Replace keeps everything but the key lines and writes to the

--- a/crates/tincd/src/script.rs
+++ b/crates/tincd/src/script.rs
@@ -57,11 +57,10 @@ use std::thread;
 use std::time::Duration;
 
 /// One script invocation's environment as `(key, value)` pairs for
-/// [`Command::envs`]. Keys are `&'static str` (all literals); values are
-/// formatted `String`s.
+/// [`Command::envs`].
 #[derive(Clone)]
 pub(crate) struct ScriptEnv {
-    vars: Vec<(&'static str, String)>,
+    vars: Vec<(String, String)>,
 }
 
 impl ScriptEnv {
@@ -81,17 +80,17 @@ impl ScriptEnv {
         // REMOTEADDRESS, REMOTEPORT, SUBNET, WEIGHT). 10 is right.
         let mut vars = Vec::with_capacity(10);
         if let Some(n) = netname {
-            vars.push(("NETNAME", n.to_owned()));
+            vars.push(("NETNAME".into(), n.to_owned()));
         }
-        vars.push(("NAME", myname.to_owned()));
+        vars.push(("NAME".into(), myname.to_owned()));
         if let Some(d) = device {
-            vars.push(("DEVICE", d.to_owned()));
+            vars.push(("DEVICE".into(), d.to_owned()));
         }
         if let Some(i) = iface {
-            vars.push(("INTERFACE", i.to_owned()));
+            vars.push(("INTERFACE".into(), i.to_owned()));
         }
         if let Some(level) = debug {
-            vars.push(("DEBUG", level.to_string()));
+            vars.push(("DEBUG".into(), level.to_string()));
         }
         Self { vars }
     }
@@ -99,8 +98,8 @@ impl ScriptEnv {
     /// `environment_add` for one var. We take key + formatted
     /// value. Call sites: NODE, REMOTEADDRESS, REMOTEPORT,
     /// SUBNET, WEIGHT.
-    pub(crate) fn add(&mut self, key: &'static str, value: String) {
-        self.vars.push((key, value));
+    pub(crate) fn add(&mut self, key: impl Into<String>, value: String) {
+        self.vars.push((key.into(), value));
     }
 }
 
@@ -154,7 +153,7 @@ fn prepare(
         None => Command::new(&scriptname),
     };
     // Inherit daemon env (matches upstream C `system()`); add tinc vars on top.
-    cmd.envs(env.vars.iter().map(|(k, v)| (*k, v.as_str())));
+    cmd.envs(env.vars.iter().map(|(k, v)| (k, v)));
     cmd.current_dir(confbase);
     Ok(cmd)
 }
@@ -361,13 +360,13 @@ mod tests {
             Some("tun0"),
             Some(2),
         );
-        let keys: Vec<_> = env.vars.iter().map(|(k, _)| *k).collect();
+        let keys: Vec<_> = env.vars.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, ["NETNAME", "NAME", "DEVICE", "INTERFACE", "DEBUG"]);
         assert_eq!(env.vars[4].1, "2");
 
         // None branches: only NAME survives.
         let env = ScriptEnv::base(None, "alpha", None, None, None);
-        let keys: Vec<_> = env.vars.iter().map(|(k, _)| *k).collect();
+        let keys: Vec<_> = env.vars.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, ["NAME"]);
     }
 

--- a/crates/tincd/tests/two_daemons/reload.rs
+++ b/crates/tincd/tests/two_daemons/reload.rs
@@ -251,7 +251,10 @@ fn replace_invite_rekeys_node_and_drops_old_device() {
     let hook_out = alice.confbase.join("hook.out");
     fs::write(
         &hook,
-        format!("#!/bin/sh\necho \"$REPLACE\" > '{}'\n", hook_out.display()),
+        format!(
+            "#!/bin/sh\necho \"$REPLACE $KARTEI_NS\" > '{}'\n",
+            hook_out.display()
+        ),
     )
     .unwrap();
     fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).unwrap();
@@ -265,10 +268,12 @@ fn replace_invite_rekeys_node_and_drops_old_device() {
     )
     .unwrap();
     let alice_paths = cli_paths(alice.confbase.clone());
-    let err = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", false, SystemTime::now())
-        .unwrap_err();
+    let now = SystemTime::now();
+    let err =
+        tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", false, &[], now).unwrap_err();
     assert!(err.to_string().contains("already exists"), "{err}");
-    let url = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", true, SystemTime::now())
+    let env = [("KARTEI_NS".to_owned(), "mic92".to_owned())];
+    let url = tinc_tools::cmd::invite::invite(&alice_paths, None, "bob", true, &env, now)
         .unwrap()
         .url;
     assert_eq!(alice.ctl().reload(), 0);
@@ -289,7 +294,10 @@ fn replace_invite_rekeys_node_and_drops_old_device() {
     assert!(!new_host.contains(&old_b64));
     assert!(fs::read_to_string(&hosts_bob).unwrap().contains(&old_b64));
     assert!(wait_for_file(&hook_out));
-    assert_eq!(fs::read_to_string(&hook_out).unwrap().trim(), old_b64);
+    assert_eq!(
+        fs::read_to_string(&hook_out).unwrap().trim(),
+        format!("{old_b64} mic92")
+    );
 
     // Old bob was kicked and stays out when it retries with the old key.
     alice.wait_for_peer("bob", false, Duration::from_secs(10));

--- a/docs/COMPAT.md
+++ b/docs/COMPAT.md
@@ -69,10 +69,12 @@ participate.
   deployments where `hosts/` is read-only. Invited nodes are written
   there, override `hosts/`, and `invitation-accepted` gets the path in
   `HOST_FILE`.
-- **`tinc invite --replace NODE`.** Re-keys an existing node through an
-  invitation (new phone, lost key). The invitation file starts with
-  `#replace <oldkey>`. A C tincd serving such a file refuses the join
-  with "host file exists", so mixed setups fail safe.
+- **`tinc invite [-e KEY=VAL] [--replace] NODE`.** `--replace` re-keys
+  an existing node through an invitation (new phone, lost key). `-e`
+  passes values to both invitation scripts. Both are stored as `#`
+  header lines before `Name =` which tincd strips before sending. A C
+  tincd serving such a file refuses the join, so mixed setups fail
+  safe.
 - **`SPTPSCipher` host key.** Selects AES-256-GCM instead of
   ChaCha20-Poly1305 for the SPTPS record AEAD on a per-edge basis.
   On AES-NI/PMULL hardware this roughly doubles tunnel throughput.

--- a/man/tinc.8
+++ b/man/tinc.8
@@ -144,10 +144,20 @@ overwrite existing files.
 .Pq or Cm export-all
 followed by
 .Cm import .
-.It Cm invite Oo Fl -replace Oc Ar NODE
+.It Cm invite Oo Fl e Ar KEY=VAL Oc Oo Fl -replace Oc Ar NODE
 Generate an invitation URL for
 .Ar NODE
 and print it to stdout.
+Each
+.Fl e
+is stored in the invitation and exported to the
+.Pa invitation-created
+and
+.Pa invitation-accepted
+scripts, e.g.\&
+.Li -e OWNER=alice
+for a script that records who a node belongs to.
+The invitee never sees these values.
 With
 .Fl -replace ,
 .Ar NODE


### PR DESCRIPTION
Values known at invite time (which user, which registry namespace) were lost by the time `invitation-accepted` ran in the daemon. `-e KEY=VAL` stores them as `#env` header lines next to `#replace` and exports them to both invitation scripts. The invitee never sees them.
