### PR TITLE
tincd: run invitation-accepted on the script worker

### DIFF
--- a/crates/tincd/src/daemon/metaconn.rs
+++ b/crates/tincd/src/daemon/metaconn.rs
@@ -19,7 +19,7 @@ use crate::keys;
 use crate::outgoing::ProxyConfig;
 use crate::script::ScriptEnv;
 use crate::tunnel::MTU;
-use crate::{invitation_serve, script, socks};
+use crate::{invitation_serve, socks};
 
 use crate::addrcache::AddressCache;
 use crate::dispatch::REQ_DISCONNECT;
@@ -1097,10 +1097,8 @@ impl Daemon {
             env.add("REMOTEADDRESS", a.ip().to_string());
             env.add("REMOTEPORT", a.port().to_string());
         }
-        Self::log_script(
-            "invitation-accepted",
-            script::execute(&self.confbase, "invitation-accepted", &env, None),
-        );
+        // Queued so a slow hook cannot delay the joiner's ACK.
+        self.submit_script("invitation-accepted".to_owned(), env);
     }
 }
 

--- a/crates/tincd/src/daemon/periodic.rs
+++ b/crates/tincd/src/daemon/periodic.rs
@@ -409,7 +409,7 @@ impl Daemon {
         self.submit_script(format!("hosts/{node}-{suffix}"), env);
     }
 
-    fn submit_script(&self, name: String, env: ScriptEnv) {
+    pub(super) fn submit_script(&self, name: String, env: ScriptEnv) {
         self.script_worker.submit(Job::Script {
             confbase: self.confbase.clone(),
             name,

--- a/crates/tincd/tests/two_daemons/reload.rs
+++ b/crates/tincd/tests/two_daemons/reload.rs
@@ -1,5 +1,5 @@
 use nix::sys::signal::Signal;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use super::common::node::has_subnet;
 use super::common::{
@@ -158,7 +158,8 @@ fn join_with_overlay_writes_there_and_peer_connects() {
     fs::write(
         &hook,
         format!(
-            "#!/bin/sh\necho \"$NODE $HOST_FILE\" > '{}'\n",
+            // A slow hook must not delay the joiner's ACK.
+            "#!/bin/sh\nsleep 3\necho \"$NODE $HOST_FILE\" > '{}'\n",
             hook_out.display()
         ),
     )
@@ -168,9 +169,11 @@ fn join_with_overlay_writes_there_and_peer_connects() {
     let (url, _) = invite_bob(&alice);
 
     let bob_confbase = tmp.path().join("bob");
+    let t0 = Instant::now();
     if let Err(err) = tinc_tools::cmd::join::join(&url, &full(&cli_paths(bob_confbase.clone()))) {
         panic!("join: {err:?}\nalice:\n{}", alice.stop());
     }
+    assert!(t0.elapsed() < Duration::from_secs(2), "{:?}", t0.elapsed());
     let overlay_bob = alice.confbase.join("hosts.local/bob");
     assert!(wait_for_file(&overlay_bob));
     assert!(!alice.confbase.join("hosts/bob").exists());


### PR DESCRIPTION
`invitation-accepted` ran synchronously before the ACK was flushed. A hook that takes a few seconds (e.g. opens a PR) made `tinc join` time out with "Invitation cancelled" although the node was registered. Queue it on the script worker like host-up.
