### PR TITLE
tests: widen daemon settle timeouts

### DIFF
--- a/crates/tincd/tests/common/mod.rs
+++ b/crates/tincd/tests/common/mod.rs
@@ -134,7 +134,7 @@ pub fn drain_stderr(mut child: Child) -> String {
 /// so poll until the pidfile is complete rather than trusting the
 /// socket as a readiness signal for it.
 fn read_pidfile(pidfile: &Path) -> String {
-    poll_until(Duration::from_secs(5), || {
+    poll_until(SETTLE, || {
         fs::read_to_string(pidfile)
             .ok()
             .filter(|content| content.contains('\n'))
@@ -164,9 +164,14 @@ pub fn read_tcp_addr(pidfile: &Path) -> net::SocketAddr {
         .expect("IPv4 listen address")
 }
 
+/// Upper bound for "the daemon or a script it forked did X". Generous
+/// because unsandboxed macOS CI scans freshly written executables on
+/// first exec while dozens of tests spawn daemons in parallel.
+pub const SETTLE: Duration = Duration::from_secs(20);
+
 /// The control socket appearing is the daemon's readiness signal.
 pub fn wait_for_file(path: &Path) -> bool {
-    wait_for_file_with(path, Duration::from_secs(5))
+    wait_for_file_with(path, SETTLE)
 }
 
 pub fn wait_for_file_with(path: &Path, timeout: Duration) -> bool {

--- a/crates/tincd/tests/common/node.rs
+++ b/crates/tincd/tests/common/node.rs
@@ -22,7 +22,7 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use super::{
-    ChildWithLog, Ctl, pubkey_from_seed, read_tcp_addr, tincd_at, wait_for_file,
+    ChildWithLog, Ctl, SETTLE, pubkey_from_seed, read_tcp_addr, tincd_at, wait_for_file,
     write_ed25519_privkey,
 };
 use std::fs;
@@ -297,7 +297,7 @@ impl Node {
             .as_mut()
             .unwrap_or_else(|| panic!("{name} not started"));
         daemon
-            .wait_exit(Duration::from_secs(5))
+            .wait_exit(SETTLE)
             .unwrap_or_else(|| panic!("{name} did not exit; stderr:\n{}", daemon.log_snapshot()))
     }
 


### PR DESCRIPTION
`tinc_up_runs_in_confbase` timed out after 5s on the unsandboxed aarch64-darwin builder (build 127) while tincd was still waiting on the freshly written script. One shared 20s bound for socket readiness, script side effects and daemon exit.
