### PR TITLE
android: ship the tinc CLI as libtinc.so next to tincd

### DIFF
--- a/android/sync-tincd.sh
+++ b/android/sync-tincd.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build tincd for both ABIs and place it as jniLibs/<abi>/libtincd.so.
+# Build tincd and tinc for both ABIs into jniLibs/<abi>/.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -10,4 +10,5 @@ declare -A abis=(
 for abi in "${!abis[@]}"; do
   out=$(nix build --no-link --print-out-paths ".#${abis[$abi]}")
   install -Dm755 "$out/bin/tincd" "android/app/src/main/jniLibs/$abi/libtincd.so"
+  install -Dm755 "$out/bin/tinc" "android/app/src/main/jniLibs/$abi/libtinc.so"
 done

--- a/nix/android-app.nix
+++ b/nix/android-app.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     mkdir -p app/src/main/jniLibs/${abi}
     cp ${tincd}/bin/tincd app/src/main/jniLibs/${abi}/libtincd.so
+    cp ${tincd}/bin/tinc app/src/main/jniLibs/${abi}/libtinc.so
     echo "android.aapt2FromMavenOverride=${android.aapt2}" >> gradle.properties
   '';
 

--- a/nix/tincd-android.nix
+++ b/nix/tincd-android.nix
@@ -27,7 +27,7 @@ let
     pname = "tincd-android";
     version = "0.1.0";
     strictDeps = true;
-    cargoExtraArgs = "-p tincd";
+    cargoExtraArgs = "-p tincd -p tinc-tools --bin tincd --bin tinc";
     nativeBuildInputs = [ perl ]; # openssl-src
     doCheck = false;
     CARGO_BUILD_TARGET = target;


### PR DESCRIPTION
The android cross build also produces `tinc`, and the APK/sync script ship it as libtinc.so so the app can run `tinc join`.