### PR TITLE
android: join a network from an invitation

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
     testImplementation("junit:junit:4.13.2")

--- a/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
+++ b/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
@@ -64,16 +64,59 @@ class MeshTest {
         )
     }
 
-    @Test
-    fun meshComesUp() {
-        val phoneDir = File(ctx.filesDir, "networks/default")
-        val gateDir = File(ctx.filesDir, "gate")
+    private val phoneDir = File(ctx.filesDir, "networks/default")
+    private val gateDir = File(ctx.filesDir, "gate")
+
+    private fun freshDirs(withPhone: Boolean) {
         phoneDir.deleteRecursively()
         gateDir.deleteRecursively()
-        copyAssets("mesh/phone", phoneDir)
+        if (withPhone) copyAssets("mesh/phone", phoneDir)
         copyAssets("mesh/gate", gateDir)
+    }
 
+    private fun tinc(dir: File, vararg args: String): String {
+        val bin = File(ctx.applicationInfo.nativeLibraryDir, "libtinc.so")
+        val p = ProcessBuilder(
+            bin.absolutePath, "--batch", "-c", dir.absolutePath,
+            "--pidfile", File(dir, "tincd.pid").absolutePath, *args,
+        ).redirectErrorStream(true).start()
+        val out = p.inputStream.bufferedReader().readText()
+        check(p.waitFor() == 0) { "tinc ${args.joinToString(" ")}: $out" }
+        return out
+    }
+
+    @Test
+    fun meshComesUp() {
+        freshDirs(withPhone = true)
         gate = TincdRunner(ctx, NetworkConfig.load(gateDir)).also { it.start() }
+        bringUpAndCheck()
+    }
+
+    // Phone side starts empty and is provisioned purely from an
+    // invitation issued by gate, Ifconfig/Route included.
+    @Test
+    fun joinThenMesh() {
+        freshDirs(withPhone = false)
+        File(gateDir, "hosts/phone").delete()
+        gate = TincdRunner(ctx, NetworkConfig.load(gateDir)).also { it.start() }
+        poll(10_000, "gate control socket") { File(gateDir, "tincd.pid").isFile }
+
+        val url = tinc(gateDir, "invite", "phone").lines().first { it.startsWith("127.0.0.1:") }.trim()
+        val inv = File(gateDir, "invitations").listFiles()!!.single { it.name != "ed25519_key.priv" }
+        // Stands in for an invitation-created hook on the inviter.
+        inv.writeText(
+            inv.readText().replaceFirst("#--", "Ifconfig = 10.243.42.42/16\nRoute = 10.243.0.0/16\n#--"),
+        )
+
+        Join.run(ctx, phoneDir, "tinc://join/$url")
+
+        assertTrue(File(phoneDir, "tinc.conf").readText().contains("ConnectTo = gate"))
+        assertTrue(File(phoneDir, "vpn.conf").readText() == "address 10.243.42.42/16\nroute 10.243.0.0/16\n")
+        assertTrue(File(gateDir, "hosts/phone").isFile)
+        bringUpAndCheck()
+    }
+
+    private fun bringUpAndCheck() {
         shell("appops set ${ctx.packageName} ACTIVATE_VPN allow")
         poll(10_000, "VPN consent") { android.net.VpnService.prepare(ctx) == null }
         ctx.startForegroundService(Intent(ctx, TincrVpnService::class.java))

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:label="tincr"
@@ -24,6 +27,10 @@
                 <data android:scheme="tinc" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.journeyapps.barcodescanner.CaptureActivity"
+            android:screenOrientation="fullSensor"
+            tools:replace="screenOrientation" />
         <service
             android:name=".TincrVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="tinc" />
+            </intent-filter>
         </activity>
         <service
             android:name=".TincrVpnService"

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
@@ -1,0 +1,131 @@
+package io.thalheim.tincr
+
+import android.content.Context
+import java.io.File
+import java.net.InetAddress
+
+class JoinError(message: String) : Exception(message)
+
+// Accepts an invitation by exec'ing libtinc.so, then derives vpn.conf
+// from the Ifconfig/Route lines the inviter put into the invitation.
+object Join {
+    private val SLUG = Regex("[0-9A-Za-z_-]{48}")
+
+    // `tinc://join/HOST[:PORT]/SLUG`, `tinc:HOST/SLUG` or the bare form.
+    fun parseLink(s: String): String? {
+        val t = s.trim()
+            .removePrefix("tinc://join/")
+            .removePrefix("tinc://")
+            .removePrefix("tinc:")
+        val slash = t.lastIndexOf('/')
+        if (slash <= 0 || !SLUG.matches(t.substring(slash + 1))) return null
+        return t
+    }
+
+    fun run(context: Context, dir: File, link: String) {
+        val url = parseLink(link) ?: throw JoinError("This is not an invitation link.")
+        val tinc = File(context.applicationInfo.nativeLibraryDir, "libtinc.so")
+        val tmp = File(dir.parentFile, dir.name + ".join").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        val p = ProcessBuilder(tinc.absolutePath, "--batch", "-c", tmp.absolutePath, "join", url)
+            .redirectErrorStream(true).start()
+        val out = p.inputStream.bufferedReader().readText()
+        if (p.waitFor() != 0) {
+            tmp.deleteRecursively()
+            throw JoinError(out.lines().lastOrNull { it.isNotBlank() } ?: "join failed")
+        }
+        try {
+            finish(tmp)
+        } catch (e: Exception) {
+            tmp.deleteRecursively()
+            throw e
+        }
+        dir.deleteRecursively()
+        if (!tmp.renameTo(dir)) throw JoinError("cannot move config into place")
+    }
+
+    internal fun finish(dir: File) {
+        val data = File(dir, "invitation-data").readLines()
+        val vpn = vpnConf(data)
+        File(dir, "vpn.conf").writeText(vpn)
+        File(dir, "tinc.conf").appendText("DeviceType = fd\nDevice = @tincr-tun\n")
+        val own = ownName(data)
+        // Ports below 1024 are refused for apps.
+        File(dir, "hosts/$own").let { f ->
+            if (f.readLines().none { key(it) == "port" }) f.appendText("Port = 0\n")
+        }
+        File(dir, "tinc-up").delete()
+    }
+
+    private fun key(line: String) = line.substringBefore('=').trim().lowercase()
+    private fun value(line: String) = line.substringAfter('=', "").trim()
+
+    private fun ownName(data: List<String>) =
+        data.firstOrNull { key(it) == "name" }?.let(::value) ?: throw JoinError("invitation has no Name")
+
+    // First chunk (up to the next `Name =`) is our config, later chunks
+    // are peers' host files whose Address must not sit inside a route.
+    internal fun vpnConf(data: List<String>): String {
+        val own = ownName(data)
+        val addrs = mutableListOf<CidrAddr>()
+        val routes = mutableListOf<CidrAddr>()
+        val peerAddrs = mutableListOf<String>()
+        var chunk = 0
+        for (line in data) {
+            if (line.startsWith("#")) continue
+            val k = key(line)
+            val v = value(line)
+            if (k == "name" && v != own) chunk++
+            when {
+                chunk == 0 && k == "ifconfig" -> cidr(v)?.let(addrs::add)
+                chunk == 0 && k == "route" -> cidr(v.substringBefore(' '))?.let(routes::add)
+                chunk > 0 && k == "address" -> peerAddrs.add(v.substringBefore(' '))
+            }
+        }
+        if (addrs.isEmpty()) throw JoinError("The invitation carries no address for this device.")
+        for (a in peerAddrs) {
+            val ip = runCatching { literal(a) }.getOrNull() ?: continue
+            val hit = (routes + addrs.map { subnet(it) }).firstOrNull { contains(it, ip) }
+            if (hit != null) throw JoinError("Peer address $a lies inside routed ${hit.address}/${hit.prefix}.")
+        }
+        return buildString {
+            addrs.forEach { append("address ${it.address}/${it.prefix}\n") }
+            routes.forEach { append("route ${it.address}/${it.prefix}\n") }
+        }
+    }
+
+    private fun cidr(s: String): CidrAddr? {
+        val (a, p) = s.split('/').takeIf { it.size == 2 } ?: return null
+        return CidrAddr(a, p.toIntOrNull() ?: return null)
+    }
+
+    // Only IP literals. Hostnames are not resolved here.
+    private fun literal(s: String): InetAddress? =
+        if (s.any { it.isLetter() && it !in "abcdefABCDEF" } || (':' !in s && s.count { it == '.' } != 3)) null
+        else InetAddress.getByName(s)
+
+    private fun subnet(c: CidrAddr): CidrAddr {
+        val b = InetAddress.getByName(c.address).address
+        for (i in b.indices) {
+            val keep = (c.prefix - i * 8).coerceIn(0, 8)
+            b[i] = (b[i].toInt() and (0xFF shl (8 - keep) and 0xFF)).toByte()
+        }
+        return CidrAddr(InetAddress.getByAddress(b).hostAddress!!, c.prefix)
+    }
+
+    private fun contains(net: CidrAddr, ip: InetAddress): Boolean {
+        val n = InetAddress.getByName(net.address).address
+        val a = ip.address
+        if (n.size != a.size) return false
+        var bits = net.prefix
+        for (i in n.indices) {
+            if (bits <= 0) return true
+            val mask = if (bits >= 8) 0xFF else (0xFF shl (8 - bits)) and 0xFF
+            if ((n[i].toInt() and mask) != (a[i].toInt() and mask)) return false
+            bits -= 8
+        }
+        return true
+    }
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
@@ -16,12 +16,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import io.thalheim.tincr.ui.AdvancedScreen
 import io.thalheim.tincr.ui.HomeState
+import io.thalheim.tincr.ui.JoinScreen
 import io.thalheim.tincr.ui.Link
 import io.thalheim.tincr.ui.MainScreen
 import io.thalheim.tincr.ui.OnboardingScreen
 import io.thalheim.tincr.ui.Tab
 import io.thalheim.tincr.ui.TincrTheme
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import androidx.compose.runtime.rememberCoroutineScope
 import java.io.File
 
 class MainActivity : ComponentActivity() {
@@ -30,8 +35,12 @@ class MainActivity : ComponentActivity() {
         if (it.resultCode == RESULT_OK) startVpn()
     }
 
+    // Set by a `tinc://` deep link, consumed by the join screen.
+    private var pendingLink by mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        pendingLink = intent.data?.takeIf { it.scheme == "tinc" }?.toString()
         setContent { TincrTheme { App() } }
         // adb/test entry. Consent must be pre-granted via appops.
         if (intent.getBooleanExtra("autostart", false)) {
@@ -45,6 +54,12 @@ class MainActivity : ComponentActivity() {
         var advanced by remember { mutableStateOf(false) }
         var link by remember { mutableStateOf(Link.Off) }
         var log by remember { mutableStateOf("") }
+        var joined by remember { mutableStateOf(File(netDir, "tinc.conf").isFile) }
+        var joining by remember { mutableStateOf(pendingLink != null) }
+        var joinLink by remember { mutableStateOf(pendingLink ?: "") }
+        var joinBusy by remember { mutableStateOf(false) }
+        var joinError by remember { mutableStateOf<String?>(null) }
+        val scope = rememberCoroutineScope()
         LaunchedEffect(Unit) {
             while (true) {
                 link = if (TincrVpnService.running) Link.Connected else Link.Off
@@ -53,8 +68,27 @@ class MainActivity : ComponentActivity() {
                 delay(1000)
             }
         }
-        if (!File(netDir, "tinc.conf").isFile) {
-            OnboardingScreen(onScan = ::notYet, onLink = ::notYet)
+        if (!joined && joining) {
+            BackHandler(!joinBusy) { joining = false }
+            JoinScreen(
+                joinLink, { joinLink = it; joinError = null }, joinBusy, joinError,
+                onJoin = {
+                    joinBusy = true
+                    scope.launch {
+                        joinError = withContext(Dispatchers.IO) {
+                            runCatching { Join.run(this@MainActivity, netDir, joinLink) }
+                                .exceptionOrNull()?.message
+                        }
+                        joinBusy = false
+                        joined = joinError == null
+                    }
+                },
+                onBack = { joining = false },
+            )
+            return
+        }
+        if (!joined) {
+            OnboardingScreen(onScan = ::notYet, onLink = { joining = true })
             return
         }
         if (advanced) {
@@ -73,7 +107,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun notYet() {
-        Toast.makeText(this, "Joining is not implemented yet", Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, "Scanning is not implemented yet", Toast.LENGTH_SHORT).show()
     }
 
     private fun sendHelpReport(log: String) {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
@@ -3,11 +3,12 @@ package io.thalheim.tincr
 import android.content.Intent
 import android.net.VpnService
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,8 +36,11 @@ class MainActivity : ComponentActivity() {
         if (it.resultCode == RESULT_OK) startVpn()
     }
 
-    // Set by a `tinc://` deep link, consumed by the join screen.
+    // Set by a `tinc://` deep link or a QR scan, consumed by the join screen.
     private var pendingLink by mutableStateOf<String?>(null)
+    private val scan = registerForActivityResult(ScanContract()) { r ->
+        r.contents?.let { pendingLink = it }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,8 +59,15 @@ class MainActivity : ComponentActivity() {
         var link by remember { mutableStateOf(Link.Off) }
         var log by remember { mutableStateOf("") }
         var joined by remember { mutableStateOf(File(netDir, "tinc.conf").isFile) }
-        var joining by remember { mutableStateOf(pendingLink != null) }
-        var joinLink by remember { mutableStateOf(pendingLink ?: "") }
+        var joining by remember { mutableStateOf(false) }
+        var joinLink by remember { mutableStateOf("") }
+        LaunchedEffect(pendingLink) {
+            pendingLink?.let {
+                joinLink = it
+                joining = true
+                pendingLink = null
+            }
+        }
         var joinBusy by remember { mutableStateOf(false) }
         var joinError by remember { mutableStateOf<String?>(null) }
         val scope = rememberCoroutineScope()
@@ -88,7 +99,7 @@ class MainActivity : ComponentActivity() {
             return
         }
         if (!joined) {
-            OnboardingScreen(onScan = ::notYet, onLink = { joining = true })
+            OnboardingScreen(onScan = ::scanQr, onLink = { joining = true })
             return
         }
         if (advanced) {
@@ -106,8 +117,11 @@ class MainActivity : ComponentActivity() {
         )
     }
 
-    private fun notYet() {
-        Toast.makeText(this, "Scanning is not implemented yet", Toast.LENGTH_SHORT).show()
+    private fun scanQr() {
+        scan.launch(
+            ScanOptions().setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                .setPrompt("Scan the invitation code").setBeepEnabled(false).setOrientationLocked(false),
+        )
     }
 
     private fun sendHelpReport(log: String) {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/ui/Screens.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/ui/Screens.kt
@@ -25,11 +25,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Link
@@ -78,6 +81,44 @@ fun OnboardingScreen(onScan: () -> Unit, onLink: () -> Unit) {
         Spacer(Modifier.weight(1f))
         Muted("No account. No sign-up.\nThe invitation is all you need.")
         Spacer(Modifier.height(28.dp))
+    }
+}
+
+// Paste-a-link step of onboarding. `busy` while the exchange runs,
+// `error` is shown verbatim under the field.
+@Composable
+fun JoinScreen(
+    link: String,
+    onLink: (String) -> Unit,
+    busy: Boolean,
+    error: String?,
+    onJoin: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(
+        Modifier.fillMaxSize().background(Palette.bg).statusBarsPadding().padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(Modifier.height(96.dp))
+        Text("Paste your invitation", fontSize = 22.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(10.dp))
+        Muted("It looks like tinc://join/… and works once.")
+        Spacer(Modifier.height(28.dp))
+        OutlinedTextField(
+            link, onLink, Modifier.fillMaxWidth(), enabled = !busy, singleLine = true,
+            label = { Text("Invitation link") }, isError = error != null,
+            supportingText = { if (error != null) Text(error, color = Palette.amberInk) },
+        )
+        Spacer(Modifier.height(20.dp))
+        if (busy) {
+            CircularProgressIndicator(color = Palette.blue)
+            Spacer(Modifier.height(12.dp))
+            Muted("Joining…")
+        } else {
+            BigButton("Join network", Icons.Filled.Link, primary = true, onJoin)
+            Spacer(Modifier.height(14.dp))
+            BigButton("Back", Icons.AutoMirrored.Filled.ArrowBack, primary = false, onBack)
+        }
     }
 }
 

--- a/android/app/src/test/kotlin/io/thalheim/tincr/JoinTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/JoinTest.kt
@@ -1,0 +1,52 @@
+package io.thalheim.tincr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class JoinTest {
+    private val slug = "A".repeat(48)
+
+    @Test
+    fun parsesLinks() {
+        assertEquals("h:1/$slug", Join.parseLink("tinc://join/h:1/$slug"))
+        assertEquals("h/$slug", Join.parseLink(" h/$slug\n"))
+        assertEquals("[::1]:655/$slug", Join.parseLink("tinc:[::1]:655/$slug"))
+        assertNull(Join.parseLink("h/short"))
+        assertNull(Join.parseLink("https://example.com/"))
+    }
+
+    @Test
+    fun vpnConfFromInvitation() {
+        val data = """
+            Name = phone
+            ConnectTo = gate
+            Ifconfig = 10.243.42.42/16
+            Route = 10.243.0.0/16
+            Route = 42::/16
+            #-------------------------------------#
+            Name = gate
+            Address = 192.0.2.1 655
+            Subnet = 10.243.0.1
+        """.trimIndent().lines()
+        assertEquals("address 10.243.42.42/16\nroute 10.243.0.0/16\nroute 42::/16\n", Join.vpnConf(data))
+    }
+
+    @Test
+    fun peerAddressInsideRouteIsRefused() {
+        val data = """
+            Name = phone
+            Ifconfig = 10.243.42.42/16
+            Name = gate
+            Address = 10.243.0.1
+        """.trimIndent().lines()
+        val e = assertThrows(JoinError::class.java) { Join.vpnConf(data) }
+        assertEquals("Peer address 10.243.0.1 lies inside routed 10.243.0.0/16.", e.message)
+    }
+
+    @Test
+    fun missingIfconfigIsRefused() {
+        assertThrows(JoinError::class.java) { Join.vpnConf(listOf("Name = phone")) }
+    }
+}

--- a/android/app/src/test/kotlin/io/thalheim/tincr/ScreenshotTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/ScreenshotTest.kt
@@ -7,6 +7,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import io.thalheim.tincr.ui.AdvancedScreen
 import io.thalheim.tincr.ui.Device
 import io.thalheim.tincr.ui.HomeState
+import io.thalheim.tincr.ui.JoinScreen
 import io.thalheim.tincr.ui.Link
 import io.thalheim.tincr.ui.MainScreen
 import io.thalheim.tincr.ui.Notice
@@ -52,6 +53,10 @@ class ScreenshotTest {
         MainScreen(state, tab, onTab = {}, onToggle = {}, onHelpReport = {}, onSettings = {})
 
     @Test fun onboarding() = shot("1_onboarding") { OnboardingScreen({}, {}) }
+    @Test fun join() = shot("1_join") { JoinScreen("tinc://join/example.org/" + "x".repeat(48), {}, false, null, {}, {}) }
+    @Test fun joinError() =
+        shot("1_join_error") { JoinScreen("nope", {}, false, "This is not an invitation link.", {}, {}) }
+    @Test fun joinBusy() = shot("1_join_busy") { JoinScreen("", {}, true, null, {}, {}) }
     @Test fun homeConnected() = shot("2_home_connected") { main(family, Tab.Home) }
     @Test fun homeOff() = shot("2_home_off") { main(family.copy(link = Link.Off), Tab.Home) }
     @Test fun homeConnecting() = shot("2_home_connecting") { main(family.copy(link = Link.Connecting), Tab.Home) }

--- a/nix/android-app-deps.json
+++ b/nix/android-app-deps.json
@@ -1036,6 +1036,13 @@
    "jar": "sha256-5afGScVMQSBJkIJHyl4l/mkh10aEnGAXqE3GBEI3pLQ=",
    "pom": "sha256-3gVzL73LWwXhmYWrwKKE5Bvj7GhTh9BPhIil5lBOoI4="
   },
+  "com/google/zxing#core/3.4.1": {
+   "jar": "sha256-rPowM4wmJntsq2ZVCcIlG7lug1C/ytidWblJuncBH40=",
+   "pom": "sha256-saD67kJKPHdVNMgfoW9aXVqmXKQOathX9pYbMz6jn9M="
+  },
+  "com/google/zxing#zxing-parent/3.4.1": {
+   "pom": "sha256-ICgf4RuOS9TBfe7FYURNFXW9Uy/stz7Pa4nv2tfNiTg="
+  },
   "com/googlecode/juniversalchardet#juniversalchardet/1.0.3": {
    "jar": "sha256-dXv+kGGTuLZR553CbNZ9a1XQdwos37A4FZFQT3edSnY=",
    "pom": "sha256-eEY5mzXHzWQqmzoADD4tYtBOs3pFR7aTPMixi8wvCGs="
@@ -1046,6 +1053,12 @@
   "com/ibm/icu#icu4j/75.1": {
    "jar": "sha256-VD5DqR0UmeMxxxGnVvgz1vuMwBn5yZE8C99NUwCZMtU=",
    "pom": "sha256-zQuqR3iLDwfDHUpJMvYY1Mqf/TADrj3Cyt5T32cI8CA="
+  },
+  "com/journeyapps#zxing-android-embedded/4.3.0": {
+   "pom": "sha256-xN0Jl0M1wh7+58opGD7K5e9+JrSCZaYFxlOj785H8ps="
+  },
+  "com/journeyapps/zxing-android-embedded/4.3.0/zxing-android-embedded-4.3.0": {
+   "aar": "sha256-SrAzUxJ8NOVcu4D7yaNAMd7Lz7HsXo+ZGUTS1JRiGjM="
   },
   "com/squareup#javapoet/1.10.0": {
    "jar": "sha256-IO9LguQ/98ZSKBohMTzzuUEJJGet0/pzUJwm9pae/as=",

--- a/nix/android-mesh-check.nix
+++ b/nix/android-mesh-check.nix
@@ -41,7 +41,7 @@ runCommand "android-mesh-check"
     adb shell am instrument -w \
       io.thalheim.tincr.test/androidx.test.runner.AndroidJUnitRunner \
       | tee instrument.log
-    grep -q "OK (1 test" instrument.log
+    grep -q "OK (2 tests" instrument.log
 
     adb emu kill || true
     touch $out


### PR DESCRIPTION
Paste screen, `tinc://` deep link and QR scan (zxing-android-embedded). The exchange runs through libtinc.so, vpn.conf is derived from Ifconfig/Route in the invitation and peer addresses inside a routed subnet are refused. The emulator check provisions the phone purely from `tinc invite` on the peer.