### PR TITLE
android: drive the home screen from real state

### DIFF
--- a/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
+++ b/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
@@ -111,7 +111,7 @@ class MeshTest {
         Join.run(ctx, phoneDir, "tinc://join/$url")
 
         assertTrue(File(phoneDir, "tinc.conf").readText().contains("ConnectTo = gate"))
-        assertTrue(File(phoneDir, "vpn.conf").readText() == "address 10.243.42.42/16\nroute 10.243.0.0/16\n")
+        assertTrue(File(phoneDir, "vpn.conf").readText() == "inviter gate\naddress 10.243.42.42/16\nroute 10.243.0.0/16\n")
         assertTrue(File(gateDir, "hosts/phone").isFile)
         bringUpAndCheck()
     }
@@ -139,6 +139,7 @@ class MeshTest {
             }
         }
         assertTrue(log(phoneLog).contains("Ready"))
+        poll(10_000, "dump nodes over control socket") { TincCtl(phoneDir).nodes()["gate"] == true }
     }
 
     @After

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
@@ -69,6 +69,8 @@ object Join {
     // are peers' host files whose Address must not sit inside a route.
     internal fun vpnConf(data: List<String>): String {
         val own = ownName(data)
+        var network: String? = null
+        var inviter: String? = null
         val addrs = mutableListOf<CidrAddr>()
         val routes = mutableListOf<CidrAddr>()
         val peerAddrs = mutableListOf<String>()
@@ -79,6 +81,8 @@ object Join {
             val v = value(line)
             if (k == "name" && v != own) chunk++
             when {
+                chunk == 0 && k == "netname" -> network = v
+                chunk == 0 && k == "connectto" && inviter == null -> inviter = v
                 chunk == 0 && k == "ifconfig" -> cidr(v)?.let(addrs::add)
                 chunk == 0 && k == "route" -> cidr(v.substringBefore(' '))?.let(routes::add)
                 chunk > 0 && k == "address" -> peerAddrs.add(v.substringBefore(' '))
@@ -91,6 +95,8 @@ object Join {
             if (hit != null) throw JoinError("Peer address $a lies inside routed ${hit.address}/${hit.prefix}.")
         }
         return buildString {
+            network?.let { append("network $it\n") }
+            inviter?.let { append("inviter $it\n") }
             addrs.forEach { append("address ${it.address}/${it.prefix}\n") }
             routes.forEach { append("route ${it.address}/${it.prefix}\n") }
         }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import io.thalheim.tincr.ui.AdvancedScreen
+import io.thalheim.tincr.ui.Device
 import io.thalheim.tincr.ui.HomeState
 import io.thalheim.tincr.ui.JoinScreen
 import io.thalheim.tincr.ui.Link
@@ -56,8 +57,8 @@ class MainActivity : ComponentActivity() {
     private fun App() {
         var tab by remember { mutableStateOf(Tab.Home) }
         var advanced by remember { mutableStateOf(false) }
-        var link by remember { mutableStateOf(Link.Off) }
         var log by remember { mutableStateOf("") }
+        var state by remember { mutableStateOf(homeState(emptyMap(), false)) }
         var joined by remember { mutableStateOf(File(netDir, "tinc.conf").isFile) }
         var joining by remember { mutableStateOf(false) }
         var joinLink by remember { mutableStateOf("") }
@@ -73,9 +74,14 @@ class MainActivity : ComponentActivity() {
         val scope = rememberCoroutineScope()
         LaunchedEffect(Unit) {
             while (true) {
-                link = if (TincrVpnService.running) Link.Connected else Link.Off
-                val f = File(netDir, "tincd.log")
-                log = if (f.isFile) f.readLines().takeLast(200).joinToString("\n") else "(no log)"
+                val running = TincrVpnService.running
+                val (nodes, tail) = withContext(Dispatchers.IO) {
+                    val f = File(netDir, "tincd.log")
+                    (if (running) TincCtl(netDir).nodes() else emptyMap()) to
+                        (if (f.isFile) f.readLines().takeLast(200).joinToString("\n") else "(no log)")
+                }
+                state = homeState(nodes, running)
+                log = tail
                 delay(1000)
             }
         }
@@ -107,13 +113,26 @@ class MainActivity : ComponentActivity() {
             AdvancedScreen(log, onBack = { advanced = false })
             return
         }
-        // Devices and inviter will come from invitation metadata. Not wired yet.
-        val state = HomeState(network = "tincr", link = link, devices = emptyList(), inviter = "your admin")
         MainScreen(
             state, tab, onTab = { tab = it },
             onToggle = { if (TincrVpnService.running) stop() else prepareAndStart() },
             onHelpReport = { sendHelpReport(log) },
             onSettings = { advanced = true },
+        )
+    }
+
+    // Connected once any peer is reachable, so the ring does not turn
+    // green on a daemon that is up but alone.
+    private fun homeState(nodes: Map<String, Boolean>, running: Boolean): HomeState {
+        val cfg = NetworkConfig.load(netDir)
+        val self = cfg.name
+        val devices = cfg.hosts.map { Device(it, "", online = nodes[it] == true, self = it == self) }
+        val anyPeer = devices.any { it.online && !it.self }
+        return HomeState(
+            network = cfg.network ?: "tincr",
+            link = if (!running) Link.Off else if (anyPeer) Link.Connected else Link.Connecting,
+            devices = devices,
+            inviter = cfg.inviter ?: "the person who invited you",
         )
     }
 

--- a/android/app/src/main/kotlin/io/thalheim/tincr/NetworkConfig.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/NetworkConfig.kt
@@ -7,12 +7,23 @@ data class CidrAddr(val address: String, val prefix: Int)
 // App-side settings from vpn.conf next to the tinc config tree.
 data class NetworkConfig(
     val dir: File,
+    val network: String?,
+    val inviter: String?,
     val addresses: List<CidrAddr>,
     val routes: List<CidrAddr>,
     val dnsServers: List<String>,
     val searchDomains: List<String>,
     val mtu: Int,
 ) {
+    val name: String?
+        get() = File(dir, "tinc.conf").takeIf { it.isFile }?.useLines { lines ->
+            lines.map { it.split("=", limit = 2) }
+                .firstOrNull { it.size == 2 && it[0].trim().equals("Name", ignoreCase = true) }
+                ?.get(1)?.trim()
+        }
+    val hosts: List<String>
+        get() = File(dir, "hosts").list()?.sorted().orEmpty()
+
     companion object {
         fun load(dir: File): NetworkConfig {
             val addresses = mutableListOf<CidrAddr>()
@@ -20,6 +31,8 @@ data class NetworkConfig(
             val dns = mutableListOf<String>()
             val domains = mutableListOf<String>()
             var mtu = 1400
+            var network: String? = null
+            var inviter: String? = null
 
             val f = File(dir, "vpn.conf")
             if (f.isFile) {
@@ -29,6 +42,8 @@ data class NetworkConfig(
                     val (key, value) = t.split(Regex("\\s+"), limit = 2)
                         .takeIf { it.size == 2 } ?: return@forEachLine
                     when (key.lowercase()) {
+                        "network" -> network = value
+                        "inviter" -> inviter = value
                         "address" -> cidr(value)?.let { addresses.add(it) }
                         "route" -> cidr(value)?.let { routes.add(it) }
                         "dns" -> dns.add(value)
@@ -37,7 +52,7 @@ data class NetworkConfig(
                     }
                 }
             }
-            return NetworkConfig(dir, addresses, routes, dns, domains, mtu)
+            return NetworkConfig(dir, network, inviter, addresses, routes, dns, domains, mtu)
         }
 
         private fun cidr(s: String): CidrAddr? {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
@@ -11,6 +11,7 @@ import java.io.InputStreamReader
 class TincCtl(private val dir: File) {
     companion object {
         const val REQ_STOP = 0
+        const val REQ_DUMP_NODES = 3
         const val REQ_RETRY = 10
     }
 
@@ -18,8 +19,17 @@ class TincCtl(private val dir: File) {
         File(dir, "tincd.pid").takeIf { it.isFile }
             ?.readText()?.split(Regex("\\s+"))?.getOrNull(1)
 
-    fun request(req: Int): Boolean {
-        val cookie = cookie() ?: return false
+    fun request(req: Int): Boolean = converse(req)?.let { it.lastOrNull()?.startsWith("18 $req 0") } ?: false
+
+    // Node name -> reachable, from `dump nodes` (status bit 4).
+    fun nodes(): Map<String, Boolean> = converse(REQ_DUMP_NODES).orEmpty()
+        .mapNotNull { it.split(' ') }
+        .filter { it.size > 12 }
+        .associate { it[2] to ((it[12].toIntOrNull(16) ?: 0) and 0x10 != 0) }
+
+    // Lines up to and including the `18 <req> ...` terminator.
+    private fun converse(req: Int): List<String>? {
+        val cookie = cookie() ?: return null
         return try {
             LocalSocket().use { sock ->
                 sock.connect(
@@ -30,14 +40,19 @@ class TincCtl(private val dir: File) {
                 )
                 val r = BufferedReader(InputStreamReader(sock.inputStream))
                 sock.outputStream.write("0 ^$cookie 0\n".toByteArray())
-                r.readLine() ?: return false
-                r.readLine() ?: return false
+                r.readLine() ?: return null
+                r.readLine() ?: return null
                 sock.outputStream.write("18 $req\n".toByteArray())
-                val ack = r.readLine() ?: return false
-                ack.startsWith("18 $req 0")
+                val out = mutableListOf<String>()
+                while (true) {
+                    val line = r.readLine() ?: return null
+                    out.add(line)
+                    if (line.split(' ').size <= 3) break
+                }
+                out
             }
         } catch (e: java.io.IOException) {
-            false
+            null
         }
     }
 }

--- a/android/app/src/test/kotlin/io/thalheim/tincr/JoinTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/JoinTest.kt
@@ -21,6 +21,7 @@ class JoinTest {
     fun vpnConfFromInvitation() {
         val data = """
             Name = phone
+            NetName = mesh
             ConnectTo = gate
             Ifconfig = 10.243.42.42/16
             Route = 10.243.0.0/16
@@ -30,7 +31,10 @@ class JoinTest {
             Address = 192.0.2.1 655
             Subnet = 10.243.0.1
         """.trimIndent().lines()
-        assertEquals("address 10.243.42.42/16\nroute 10.243.0.0/16\nroute 42::/16\n", Join.vpnConf(data))
+        assertEquals(
+            "network mesh\ninviter gate\naddress 10.243.42.42/16\nroute 10.243.0.0/16\nroute 42::/16\n",
+            Join.vpnConf(data),
+        )
     }
 
     @Test


### PR DESCRIPTION
Devices from hosts/, reachability from `dump nodes` over the control socket, ring connected only once a peer is reachable, inviter/network name from the invitation.