### PR TITLE
android: refresh hosts/ from a bundle URL

### DIFF
--- a/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
+++ b/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
@@ -7,6 +7,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
 import java.net.NetworkInterface
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -104,16 +105,80 @@ class MeshTest {
         val url = tinc(gateDir, "invite", "phone").lines().first { it.startsWith("127.0.0.1:") }.trim()
         val inv = File(gateDir, "invitations").listFiles()!!.single { it.name != "ed25519_key.priv" }
         // Stands in for an invitation-created hook on the inviter.
+        val port = serveBundle(mapOf("extra" to "Subnet = 10.243.9.9/32\n"))
         inv.writeText(
-            inv.readText().replaceFirst("#--", "Ifconfig = 10.243.42.42/16\nRoute = 10.243.0.0/16\n#--"),
+            inv.readText().replaceFirst(
+                "#--",
+                "Ifconfig = 10.243.42.42/16\nRoute = 10.243.0.0/16\nBundleUrl = http://127.0.0.1:$port/b.tar.gz\n#--",
+            ),
         )
 
         Join.run(ctx, phoneDir, "tinc://join/$url")
 
         assertTrue(File(phoneDir, "tinc.conf").readText().contains("ConnectTo = gate"))
-        assertTrue(File(phoneDir, "vpn.conf").readText() == "inviter gate\naddress 10.243.42.42/16\nroute 10.243.0.0/16\n")
+        assertTrue(
+            File(phoneDir, "vpn.conf").readText() ==
+                "inviter gate\nbundle http://127.0.0.1:$port/b.tar.gz\naddress 10.243.42.42/16\nroute 10.243.0.0/16\n",
+        )
         assertTrue(File(gateDir, "hosts/phone").isFile)
         bringUpAndCheck()
+
+        // VPN start fetched the bundle: new host lands, own and peer files stay.
+        poll(20_000, "bundle applied") { File(phoneDir, "hosts/extra").isFile }
+        assertTrue(File(phoneDir, "hosts/phone").isFile && File(phoneDir, "hosts/gate").isFile)
+        assertTrue(File(phoneDir, "bundle.etag").readText() == "\"v1\"")
+        assertTrue("second fetch is a 304", !Bundle.update(NetworkConfig.load(phoneDir)))
+        // VPN start and the freshly scheduled job may both fetch once.
+        val hits = synchronized(bundleHits) { bundleHits.toList() }
+        assertEquals(hits.toString(), "\"v1\"", hits.last())
+        assertTrue(hits.toString(), hits.dropLast(1).all { it == null || it == "\"v1\"" })
+    }
+
+    private val bundleHits = mutableListOf<String?>()
+
+    // One-thread HTTP server handing out a tar.gz of `hosts` (plus gate)
+    // with ETag "v1". Records If-None-Match of each request.
+    private fun serveBundle(hosts: Map<String, String>): Int {
+        val all = hosts + ("gate" to File(gateDir, "hosts/gate").readText())
+        val tgz = java.io.ByteArrayOutputStream().also { out ->
+            java.util.zip.GZIPOutputStream(out).use { gz ->
+                for ((name, body) in all) {
+                    val b = body.toByteArray()
+                    val hdr = ByteArray(512)
+                    name.toByteArray().copyInto(hdr, 0)
+                    "0000644".toByteArray().copyInto(hdr, 100)
+                    String.format("%011o", b.size).toByteArray().copyInto(hdr, 124)
+                    hdr[156] = '0'.code.toByte()
+                    gz.write(hdr); gz.write(b); gz.write(ByteArray((512 - b.size % 512) % 512))
+                }
+                gz.write(ByteArray(1024))
+            }
+        }.toByteArray()
+        val srv = java.net.ServerSocket(0, 8, java.net.InetAddress.getByName("127.0.0.1"))
+        Thread {
+            while (true) {
+                val s = try { srv.accept() } catch (e: Exception) { return@Thread }
+                s.use {
+                    val r = it.getInputStream().bufferedReader()
+                    var etag: String? = null
+                    while (true) {
+                        val l = r.readLine() ?: break
+                        if (l.isEmpty()) break
+                        if (l.startsWith("If-None-Match:", ignoreCase = true)) etag = l.substringAfter(':').trim()
+                    }
+                    synchronized(bundleHits) { bundleHits.add(etag) }
+                    val o = it.getOutputStream()
+                    if (etag == "\"v1\"") {
+                        o.write("HTTP/1.1 304 Not Modified\r\nETag: \"v1\"\r\nConnection: close\r\n\r\n".toByteArray())
+                    } else {
+                        o.write("HTTP/1.1 200 OK\r\nETag: \"v1\"\r\nContent-Length: ${tgz.size}\r\nConnection: close\r\n\r\n".toByteArray())
+                        o.write(tgz)
+                    }
+                    o.flush()
+                }
+            }
+        }.apply { isDaemon = true }.start()
+        return srv.localPort
     }
 
     private fun bringUpAndCheck() {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,11 +7,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:label="tincr"
         android:extractNativeLibs="true"
+        android:networkSecurityConfig="@xml/network_security"
         android:allowBackup="false">
         <activity
             android:name=".MainActivity"
@@ -31,6 +33,10 @@
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="fullSensor"
             tools:replace="screenOrientation" />
+        <service
+            android:name=".BundleJob"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
         <service
             android:name=".TincrVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
@@ -57,11 +57,9 @@ object Bundle {
             throw java.io.IOException("bundle has no host files")
         }
         val hosts = File(dir, "hosts")
-        config.name?.let { own ->
-            File(hosts, own).takeIf { it.isFile }?.copyTo(File(fresh, own), overwrite = true)
-        }
+        config.name?.let { own -> File(hosts, own).takeIf { it.isFile }?.copyTo(File(fresh, own), overwrite = true) }
         val old = File(dir, "hosts.old").apply { deleteRecursively() }
-        if (hosts.exists() && !hosts.renameTo(old)) throw java.io.IOException("cannot move hosts aside")
+        hosts.renameTo(old)
         if (!fresh.renameTo(hosts)) {
             old.renameTo(hosts)
             throw java.io.IOException("cannot move hosts into place")
@@ -75,12 +73,8 @@ object Bundle {
         val din = DataInputStream(input)
         val hdr = ByteArray(512)
         while (true) {
-            try {
-                din.readFully(hdr)
-            } catch (e: java.io.EOFException) {
-                return
-            }
-            if (hdr.all { it == 0.toByte() }) return
+            din.readFully(hdr)
+            if (hdr[0] == 0.toByte()) return
             val name = String(hdr, 0, 100).substringBefore('\u0000').substringAfterLast('/')
             val size = String(hdr, 124, 12).trim('\u0000', ' ').ifEmpty { "0" }.toLong(8)
             val type = hdr[156].toInt().toChar()

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
@@ -12,7 +12,10 @@ import java.util.zip.GZIPInputStream
 // Our own host file survives, identity files are never touched.
 object Bundle {
     private const val TAG = "tincr"
-    private val NAME = Regex("[A-Za-z0-9_]+")
+    // `NAME`, `./NAME` or `hosts/NAME` at most 64 KiB with a host key inside.
+    private val ENTRY = Regex("(?:\\./)?(?:hosts/)?([A-Za-z0-9_]+)")
+    private val HOST_KEY = Regex("(?im)^\\s*Ed25519PublicKey\\s*=|-----BEGIN RSA PUBLIC KEY-----")
+    private const val MAX_ENTRY = 64 * 1024
 
     // True when hosts/ changed and tincd should reload.
     fun update(config: NetworkConfig): Boolean {
@@ -46,11 +49,11 @@ object Bundle {
             mkdirs()
         }
         var n = 0
-        untar(GZIPInputStream(tgz)) { name, body ->
-            if (NAME.matches(name)) {
-                File(fresh, name).writeBytes(body)
-                n++
-            }
+        untar(GZIPInputStream(tgz)) { path, body ->
+            val name = ENTRY.matchEntire(path)?.groupValues?.get(1) ?: return@untar
+            if (!HOST_KEY.containsMatchIn(String(body))) return@untar
+            File(fresh, name).writeBytes(body)
+            n++
         }
         if (n == 0) {
             fresh.deleteRecursively()
@@ -68,20 +71,27 @@ object Bundle {
         return n
     }
 
-    // ustar reader, regular files only, basename of each entry.
+    // ustar reader. Hands regular files up to MAX_ENTRY to `entry`, skips
+    // everything else (dirs, links, pax headers, big files).
     private fun untar(input: InputStream, entry: (String, ByteArray) -> Unit) {
         val din = DataInputStream(input)
         val hdr = ByteArray(512)
         while (true) {
             din.readFully(hdr)
             if (hdr[0] == 0.toByte()) return
-            val name = String(hdr, 0, 100).substringBefore('\u0000').substringAfterLast('/')
+            val path = String(hdr, 0, 100).substringBefore('\u0000')
             val size = String(hdr, 124, 12).trim('\u0000', ' ').ifEmpty { "0" }.toLong(8)
             val type = hdr[156].toInt().toChar()
-            val body = ByteArray(size.toInt())
-            din.readFully(body)
-            din.skipBytes(((512 - size % 512) % 512).toInt())
-            if ((type == '0' || type == '\u0000') && name.isNotEmpty()) entry(name, body)
+            val padded = size + (512 - size % 512) % 512
+            if ((type == '0' || type == '\u0000') && size <= MAX_ENTRY) {
+                val body = ByteArray(size.toInt())
+                din.readFully(body)
+                din.skipBytes((padded - size).toInt())
+                entry(path, body)
+            } else {
+                var left = padded
+                while (left > 0) left -= din.skip(left).also { if (it <= 0) throw java.io.EOFException() }
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
@@ -1,0 +1,93 @@
+package io.thalheim.tincr
+
+import android.util.Log
+import java.io.DataInputStream
+import java.io.File
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.zip.GZIPInputStream
+
+// Replaces hosts/ from a tar.gz of host files at `bundle` in vpn.conf.
+// Our own host file survives, identity files are never touched.
+object Bundle {
+    private const val TAG = "tincr"
+    private val NAME = Regex("[A-Za-z0-9_]+")
+
+    // True when hosts/ changed and tincd should reload.
+    fun update(config: NetworkConfig): Boolean {
+        val url = config.bundleUrl ?: return false
+        val etagFile = File(config.dir, "bundle.etag")
+        val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+            connectTimeout = 15_000
+            readTimeout = 30_000
+            instanceFollowRedirects = true
+            etagFile.takeIf { it.isFile }?.let { setRequestProperty("If-None-Match", it.readText()) }
+        }
+        try {
+            when (val code = conn.responseCode) {
+                HttpURLConnection.HTTP_NOT_MODIFIED -> return false
+                HttpURLConnection.HTTP_OK -> {}
+                else -> throw java.io.IOException("bundle fetch: HTTP $code")
+            }
+            val n = conn.inputStream.use { install(config, it) }
+            conn.getHeaderField("ETag")?.let { etagFile.writeText(it) }
+            Log.i(TAG, "bundle: $n host files from $url")
+            return true
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    internal fun install(config: NetworkConfig, tgz: InputStream): Int {
+        val dir = config.dir
+        val fresh = File(dir, "hosts.new").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        var n = 0
+        untar(GZIPInputStream(tgz)) { name, body ->
+            if (NAME.matches(name)) {
+                File(fresh, name).writeBytes(body)
+                n++
+            }
+        }
+        if (n == 0) {
+            fresh.deleteRecursively()
+            throw java.io.IOException("bundle has no host files")
+        }
+        val hosts = File(dir, "hosts")
+        config.name?.let { own ->
+            File(hosts, own).takeIf { it.isFile }?.copyTo(File(fresh, own), overwrite = true)
+        }
+        val old = File(dir, "hosts.old").apply { deleteRecursively() }
+        if (hosts.exists() && !hosts.renameTo(old)) throw java.io.IOException("cannot move hosts aside")
+        if (!fresh.renameTo(hosts)) {
+            old.renameTo(hosts)
+            throw java.io.IOException("cannot move hosts into place")
+        }
+        old.deleteRecursively()
+        return n
+    }
+
+    // ustar reader, regular files only, basename of each entry.
+    private fun untar(input: InputStream, entry: (String, ByteArray) -> Unit) {
+        val din = DataInputStream(input)
+        val hdr = ByteArray(512)
+        while (true) {
+            try {
+                din.readFully(hdr)
+            } catch (e: java.io.EOFException) {
+                return
+            }
+            if (hdr.all { it == 0.toByte() }) return
+            val name = String(hdr, 0, 100).substringBefore('\u0000').substringAfterLast('/')
+            val size = String(hdr, 124, 12).trim('\u0000', ' ').ifEmpty { "0" }.toLong(8)
+            val type = hdr[156].toInt().toChar()
+            val body = ByteArray(size.toInt())
+            din.readFully(body)
+            din.skipBytes(((512 - size % 512) % 512).toInt())
+            if ((type == '0' || type == '\u0000') && name.isNotEmpty()) entry(name, body)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/BundleJob.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/BundleJob.kt
@@ -1,0 +1,54 @@
+package io.thalheim.tincr
+
+import android.app.job.JobInfo
+import android.app.job.JobParameters
+import android.app.job.JobScheduler
+import android.app.job.JobService
+import android.content.ComponentName
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+// Daily hosts/ refresh. Also run on every VPN start.
+class BundleJob : JobService() {
+    companion object {
+        private const val ID = 1
+
+        fun schedule(context: Context) {
+            val js = context.getSystemService(JobScheduler::class.java)
+            if (js.getPendingJob(ID) != null) return
+            js.schedule(
+                JobInfo.Builder(ID, ComponentName(context, BundleJob::class.java))
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                    .setPeriodic(TimeUnit.DAYS.toMillis(1))
+                    .setPersisted(true)
+                    .build(),
+            )
+        }
+
+        @Synchronized
+        fun refresh(config: NetworkConfig) {
+            try {
+                if (Bundle.update(config) && TincrVpnService.running) {
+                    TincCtl(config.dir).request(TincCtl.REQ_RELOAD)
+                }
+            } catch (e: Exception) {
+                Log.w("tincr", "bundle update failed: ${e.message}")
+            }
+        }
+    }
+
+    override fun onStartJob(params: JobParameters): Boolean {
+        val config = NetworkConfig.load(File(filesDir, "networks/default"))
+        if (config.bundleUrl == null) return false
+        thread(name = "tincr-bundle") {
+            refresh(config)
+            jobFinished(params, false)
+        }
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters) = false
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Cidr.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Cidr.kt
@@ -1,0 +1,34 @@
+package io.thalheim.tincr
+
+import java.net.InetAddress
+
+data class CidrAddr(val address: String, val prefix: Int) {
+    override fun toString() = "$address/$prefix"
+
+    operator fun contains(ip: InetAddress): Boolean {
+        val n = InetAddress.getByName(address).address
+        val a = ip.address
+        if (n.size != a.size) return false
+        for (i in n.indices) {
+            val bits = (prefix - i * 8).coerceIn(0, 8)
+            val mask = (0xFF shl (8 - bits)) and 0xFF
+            if ((n[i].toInt() and mask) != (a[i].toInt() and mask)) return false
+        }
+        return true
+    }
+
+    companion object {
+        fun parse(s: String): CidrAddr? {
+            val (a, p) = s.split('/').takeIf { it.size == 2 } ?: return null
+            return CidrAddr(a, p.toIntOrNull() ?: return null)
+        }
+    }
+}
+
+// `Key = value` or `key value`, comments and blanks skipped, key lowercased.
+fun confLines(lines: List<String>): List<Pair<String, String>> = lines.mapNotNull { line ->
+    val t = line.trim()
+    if (t.isEmpty() || t.startsWith("#")) return@mapNotNull null
+    val i = t.indexOfFirst { it == '=' || it.isWhitespace() }.takeIf { it > 0 } ?: return@mapNotNull null
+    t.substring(0, i).lowercase() to t.substring(i).trimStart().removePrefix("=").trim()
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
@@ -71,6 +71,7 @@ object Join {
         val own = ownName(data)
         var network: String? = null
         var inviter: String? = null
+        var bundle: String? = null
         val addrs = mutableListOf<CidrAddr>()
         val routes = mutableListOf<CidrAddr>()
         val peerAddrs = mutableListOf<String>()
@@ -82,6 +83,7 @@ object Join {
             if (k == "name" && v != own) chunk++
             when {
                 chunk == 0 && k == "netname" -> network = v
+                chunk == 0 && k == "bundleurl" -> bundle = v
                 chunk == 0 && k == "connectto" && inviter == null -> inviter = v
                 chunk == 0 && k == "ifconfig" -> cidr(v)?.let(addrs::add)
                 chunk == 0 && k == "route" -> cidr(v.substringBefore(' '))?.let(routes::add)
@@ -97,6 +99,7 @@ object Join {
         return buildString {
             network?.let { append("network $it\n") }
             inviter?.let { append("inviter $it\n") }
+            bundle?.let { append("bundle $it\n") }
             addrs.forEach { append("address ${it.address}/${it.prefix}\n") }
             routes.forEach { append("route ${it.address}/${it.prefix}\n") }
         }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
@@ -10,131 +10,68 @@ class JoinError(message: String) : Exception(message)
 // from the Ifconfig/Route lines the inviter put into the invitation.
 object Join {
     private val SLUG = Regex("[0-9A-Za-z_-]{48}")
+    private val IP_LITERAL = Regex("[0-9.]+|[0-9a-fA-F:.]*:[0-9a-fA-F:.]*")
 
     // `tinc://join/HOST[:PORT]/SLUG`, `tinc:HOST/SLUG` or the bare form.
     fun parseLink(s: String): String? {
-        val t = s.trim()
-            .removePrefix("tinc://join/")
-            .removePrefix("tinc://")
-            .removePrefix("tinc:")
+        val t = s.trim().removePrefix("tinc://join/").removePrefix("tinc://").removePrefix("tinc:")
         val slash = t.lastIndexOf('/')
-        if (slash <= 0 || !SLUG.matches(t.substring(slash + 1))) return null
-        return t
+        return t.takeIf { slash > 0 && SLUG.matches(t.substring(slash + 1)) }
     }
 
     fun run(context: Context, dir: File, link: String) {
         val url = parseLink(link) ?: throw JoinError("This is not an invitation link.")
         val tinc = File(context.applicationInfo.nativeLibraryDir, "libtinc.so")
-        val tmp = File(dir.parentFile, dir.name + ".join").apply {
-            deleteRecursively()
-            mkdirs()
-        }
-        val p = ProcessBuilder(tinc.absolutePath, "--batch", "-c", tmp.absolutePath, "join", url)
-            .redirectErrorStream(true).start()
-        val out = p.inputStream.bufferedReader().readText()
-        if (p.waitFor() != 0) {
-            tmp.deleteRecursively()
-            throw JoinError(out.lines().lastOrNull { it.isNotBlank() } ?: "join failed")
-        }
+        val tmp = File(dir.parentFile, dir.name + ".join")
+        tmp.deleteRecursively()
+        tmp.mkdirs()
         try {
+            val p = ProcessBuilder(tinc.absolutePath, "--batch", "-c", tmp.absolutePath, "join", url)
+                .redirectErrorStream(true).start()
+            val out = p.inputStream.bufferedReader().readText()
+            if (p.waitFor() != 0) throw JoinError(out.lines().lastOrNull { it.isNotBlank() } ?: "join failed")
             finish(tmp)
-        } catch (e: Exception) {
+            dir.deleteRecursively()
+            if (!tmp.renameTo(dir)) throw JoinError("cannot move config into place")
+        } finally {
             tmp.deleteRecursively()
-            throw e
         }
-        dir.deleteRecursively()
-        if (!tmp.renameTo(dir)) throw JoinError("cannot move config into place")
     }
 
-    internal fun finish(dir: File) {
-        val data = File(dir, "invitation-data").readLines()
-        val vpn = vpnConf(data)
-        File(dir, "vpn.conf").writeText(vpn)
+    private fun finish(dir: File) {
+        val config = fromInvitation(dir, File(dir, "invitation-data").readLines())
+        File(dir, "vpn.conf").writeText(config.render())
         File(dir, "tinc.conf").appendText("DeviceType = fd\nDevice = @tincr-tun\n")
-        val own = ownName(data)
         // Ports below 1024 are refused for apps.
-        File(dir, "hosts/$own").let { f ->
-            if (f.readLines().none { key(it) == "port" }) f.appendText("Port = 0\n")
+        File(dir, "hosts/${config.name}").let { f ->
+            if (confLines(f.readLines()).none { it.first == "port" }) f.appendText("Port = 0\n")
         }
         File(dir, "tinc-up").delete()
     }
 
-    private fun key(line: String) = line.substringBefore('=').trim().lowercase()
-    private fun value(line: String) = line.substringAfter('=', "").trim()
-
-    private fun ownName(data: List<String>) =
-        data.firstOrNull { key(it) == "name" }?.let(::value) ?: throw JoinError("invitation has no Name")
-
     // First chunk (up to the next `Name =`) is our config, later chunks
     // are peers' host files whose Address must not sit inside a route.
-    internal fun vpnConf(data: List<String>): String {
-        val own = ownName(data)
-        var network: String? = null
-        var inviter: String? = null
-        var bundle: String? = null
-        val addrs = mutableListOf<CidrAddr>()
-        val routes = mutableListOf<CidrAddr>()
-        val peerAddrs = mutableListOf<String>()
-        var chunk = 0
-        for (line in data) {
-            if (line.startsWith("#")) continue
-            val k = key(line)
-            val v = value(line)
-            if (k == "name" && v != own) chunk++
-            when {
-                chunk == 0 && k == "netname" -> network = v
-                chunk == 0 && k == "bundleurl" -> bundle = v
-                chunk == 0 && k == "connectto" && inviter == null -> inviter = v
-                chunk == 0 && k == "ifconfig" -> cidr(v)?.let(addrs::add)
-                chunk == 0 && k == "route" -> cidr(v.substringBefore(' '))?.let(routes::add)
-                chunk > 0 && k == "address" -> peerAddrs.add(v.substringBefore(' '))
-            }
+    internal fun fromInvitation(dir: File, data: List<String>): NetworkConfig {
+        val kv = confLines(data)
+        val own = kv.firstOrNull { it.first == "name" }?.second ?: throw JoinError("invitation has no Name")
+        val mine = kv.takeWhile { (k, v) -> k != "name" || v == own }
+        val peers = kv.drop(mine.size)
+        fun all(k: String) = mine.filter { it.first == k }.map { it.second.substringBefore(' ') }
+        val config = NetworkConfig(
+            dir,
+            network = all("netname").firstOrNull(),
+            inviter = all("connectto").firstOrNull(),
+            bundleUrl = all("bundleurl").firstOrNull(),
+            addresses = all("ifconfig").mapNotNull(CidrAddr::parse),
+            routes = all("route").mapNotNull(CidrAddr::parse),
+        )
+        if (config.addresses.isEmpty()) throw JoinError("The invitation carries no address for this device.")
+        val nets = config.routes + config.addresses
+        for (a in peers.filter { it.first == "address" }.map { it.second.substringBefore(' ') }) {
+            if (!IP_LITERAL.matches(a)) continue
+            val hit = nets.firstOrNull { InetAddress.getByName(a) in it } ?: continue
+            throw JoinError("Peer address $a lies inside routed $hit.")
         }
-        if (addrs.isEmpty()) throw JoinError("The invitation carries no address for this device.")
-        for (a in peerAddrs) {
-            val ip = runCatching { literal(a) }.getOrNull() ?: continue
-            val hit = (routes + addrs.map { subnet(it) }).firstOrNull { contains(it, ip) }
-            if (hit != null) throw JoinError("Peer address $a lies inside routed ${hit.address}/${hit.prefix}.")
-        }
-        return buildString {
-            network?.let { append("network $it\n") }
-            inviter?.let { append("inviter $it\n") }
-            bundle?.let { append("bundle $it\n") }
-            addrs.forEach { append("address ${it.address}/${it.prefix}\n") }
-            routes.forEach { append("route ${it.address}/${it.prefix}\n") }
-        }
-    }
-
-    private fun cidr(s: String): CidrAddr? {
-        val (a, p) = s.split('/').takeIf { it.size == 2 } ?: return null
-        return CidrAddr(a, p.toIntOrNull() ?: return null)
-    }
-
-    // Only IP literals. Hostnames are not resolved here.
-    private fun literal(s: String): InetAddress? =
-        if (s.any { it.isLetter() && it !in "abcdefABCDEF" } || (':' !in s && s.count { it == '.' } != 3)) null
-        else InetAddress.getByName(s)
-
-    private fun subnet(c: CidrAddr): CidrAddr {
-        val b = InetAddress.getByName(c.address).address
-        for (i in b.indices) {
-            val keep = (c.prefix - i * 8).coerceIn(0, 8)
-            b[i] = (b[i].toInt() and (0xFF shl (8 - keep) and 0xFF)).toByte()
-        }
-        return CidrAddr(InetAddress.getByAddress(b).hostAddress!!, c.prefix)
-    }
-
-    private fun contains(net: CidrAddr, ip: InetAddress): Boolean {
-        val n = InetAddress.getByName(net.address).address
-        val a = ip.address
-        if (n.size != a.size) return false
-        var bits = net.prefix
-        for (i in n.indices) {
-            if (bits <= 0) return true
-            val mask = if (bits >= 8) 0xFF else (0xFF shl (8 - bits)) and 0xFF
-            if ((n[i].toInt() and mask) != (a[i].toInt() and mask)) return false
-            bits -= 8
-        }
-        return true
+        return config
     }
 }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
@@ -37,15 +37,15 @@ class MainActivity : ComponentActivity() {
         if (it.resultCode == RESULT_OK) startVpn()
     }
 
-    // Set by a `tinc://` deep link or a QR scan, consumed by the join screen.
-    private var pendingLink by mutableStateOf<String?>(null)
+    // Non-null shows the join screen. Set by deep link, QR scan or the button.
+    private var joinLink by mutableStateOf<String?>(null)
     private val scan = registerForActivityResult(ScanContract()) { r ->
-        r.contents?.let { pendingLink = it }
+        r.contents?.let { joinLink = it }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        pendingLink = intent.data?.takeIf { it.scheme == "tinc" }?.toString()
+        joinLink = intent.data?.takeIf { it.scheme == "tinc" }?.toString()
         setContent { TincrTheme { App() } }
         // adb/test entry. Consent must be pre-granted via appops.
         if (intent.getBooleanExtra("autostart", false)) {
@@ -60,15 +60,6 @@ class MainActivity : ComponentActivity() {
         var log by remember { mutableStateOf("") }
         var state by remember { mutableStateOf(homeState(emptyMap(), false)) }
         var joined by remember { mutableStateOf(File(netDir, "tinc.conf").isFile) }
-        var joining by remember { mutableStateOf(false) }
-        var joinLink by remember { mutableStateOf("") }
-        LaunchedEffect(pendingLink) {
-            pendingLink?.let {
-                joinLink = it
-                joining = true
-                pendingLink = null
-            }
-        }
         var joinBusy by remember { mutableStateOf(false) }
         var joinError by remember { mutableStateOf<String?>(null) }
         val scope = rememberCoroutineScope()
@@ -85,27 +76,27 @@ class MainActivity : ComponentActivity() {
                 delay(1000)
             }
         }
-        if (!joined && joining) {
-            BackHandler(!joinBusy) { joining = false }
+        val link = joinLink
+        if (!joined && link != null) {
+            BackHandler(!joinBusy) { joinLink = null }
             JoinScreen(
-                joinLink, { joinLink = it; joinError = null }, joinBusy, joinError,
+                link, { joinLink = it; joinError = null }, joinBusy, joinError,
                 onJoin = {
                     joinBusy = true
                     scope.launch {
                         joinError = withContext(Dispatchers.IO) {
-                            runCatching { Join.run(this@MainActivity, netDir, joinLink) }
-                                .exceptionOrNull()?.message
+                            runCatching { Join.run(this@MainActivity, netDir, link) }.exceptionOrNull()?.message
                         }
                         joinBusy = false
                         joined = joinError == null
                     }
                 },
-                onBack = { joining = false },
+                onBack = { joinLink = null },
             )
             return
         }
         if (!joined) {
-            OnboardingScreen(onScan = ::scanQr, onLink = { joining = true })
+            OnboardingScreen(onScan = ::scanQr, onLink = { joinLink = "" })
             return
         }
         if (advanced) {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.concurrent.thread
 import androidx.compose.runtime.rememberCoroutineScope
 import java.io.File
 
@@ -51,6 +52,14 @@ class MainActivity : ComponentActivity() {
         if (intent.getBooleanExtra("autostart", false)) {
             prepareAndStart()
         }
+    }
+
+    // People open the app when something is off or to look someone up,
+    // so bring hosts/ up to date right then. A conditional GET, 304 mostly.
+    override fun onResume() {
+        super.onResume()
+        val config = NetworkConfig.load(netDir)
+        if (config.bundleUrl != null) thread(name = "tincr-bundle") { BundleJob.refresh(config) }
     }
 
     @Composable

--- a/android/app/src/main/kotlin/io/thalheim/tincr/NetworkConfig.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/NetworkConfig.kt
@@ -9,6 +9,7 @@ data class NetworkConfig(
     val dir: File,
     val network: String?,
     val inviter: String?,
+    val bundleUrl: String?,
     val addresses: List<CidrAddr>,
     val routes: List<CidrAddr>,
     val dnsServers: List<String>,
@@ -33,6 +34,7 @@ data class NetworkConfig(
             var mtu = 1400
             var network: String? = null
             var inviter: String? = null
+            var bundle: String? = null
 
             val f = File(dir, "vpn.conf")
             if (f.isFile) {
@@ -44,6 +46,7 @@ data class NetworkConfig(
                     when (key.lowercase()) {
                         "network" -> network = value
                         "inviter" -> inviter = value
+                        "bundle" -> bundle = value
                         "address" -> cidr(value)?.let { addresses.add(it) }
                         "route" -> cidr(value)?.let { routes.add(it) }
                         "dns" -> dns.add(value)
@@ -52,7 +55,7 @@ data class NetworkConfig(
                     }
                 }
             }
-            return NetworkConfig(dir, network, inviter, addresses, routes, dns, domains, mtu)
+            return NetworkConfig(dir, network, inviter, bundle, addresses, routes, dns, domains, mtu)
         }
 
         private fun cidr(s: String): CidrAddr? {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/NetworkConfig.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/NetworkConfig.kt
@@ -2,67 +2,51 @@ package io.thalheim.tincr
 
 import java.io.File
 
-data class CidrAddr(val address: String, val prefix: Int)
-
 // App-side settings from vpn.conf next to the tinc config tree.
 data class NetworkConfig(
     val dir: File,
-    val network: String?,
-    val inviter: String?,
-    val bundleUrl: String?,
-    val addresses: List<CidrAddr>,
-    val routes: List<CidrAddr>,
-    val dnsServers: List<String>,
-    val searchDomains: List<String>,
-    val mtu: Int,
+    val network: String? = null,
+    val inviter: String? = null,
+    val bundleUrl: String? = null,
+    val addresses: List<CidrAddr> = emptyList(),
+    val routes: List<CidrAddr> = emptyList(),
+    val dnsServers: List<String> = emptyList(),
+    val searchDomains: List<String> = emptyList(),
+    val mtu: Int = 1400,
 ) {
     val name: String?
-        get() = File(dir, "tinc.conf").takeIf { it.isFile }?.useLines { lines ->
-            lines.map { it.split("=", limit = 2) }
-                .firstOrNull { it.size == 2 && it[0].trim().equals("Name", ignoreCase = true) }
-                ?.get(1)?.trim()
-        }
+        get() = File(dir, "tinc.conf").takeIf { it.isFile }
+            ?.let { confLines(it.readLines()) }?.firstOrNull { it.first == "name" }?.second
     val hosts: List<String>
         get() = File(dir, "hosts").list()?.sorted().orEmpty()
 
+    fun render() = buildString {
+        network?.let { append("network $it\n") }
+        inviter?.let { append("inviter $it\n") }
+        bundleUrl?.let { append("bundle $it\n") }
+        addresses.forEach { append("address $it\n") }
+        routes.forEach { append("route $it\n") }
+        dnsServers.forEach { append("dns $it\n") }
+        searchDomains.forEach { append("domain $it\n") }
+        if (mtu != 1400) append("mtu $mtu\n")
+    }
+
     companion object {
         fun load(dir: File): NetworkConfig {
-            val addresses = mutableListOf<CidrAddr>()
-            val routes = mutableListOf<CidrAddr>()
-            val dns = mutableListOf<String>()
-            val domains = mutableListOf<String>()
-            var mtu = 1400
-            var network: String? = null
-            var inviter: String? = null
-            var bundle: String? = null
-
-            val f = File(dir, "vpn.conf")
-            if (f.isFile) {
-                f.forEachLine { line ->
-                    val t = line.trim()
-                    if (t.isEmpty() || t.startsWith("#")) return@forEachLine
-                    val (key, value) = t.split(Regex("\\s+"), limit = 2)
-                        .takeIf { it.size == 2 } ?: return@forEachLine
-                    when (key.lowercase()) {
-                        "network" -> network = value
-                        "inviter" -> inviter = value
-                        "bundle" -> bundle = value
-                        "address" -> cidr(value)?.let { addresses.add(it) }
-                        "route" -> cidr(value)?.let { routes.add(it) }
-                        "dns" -> dns.add(value)
-                        "domain" -> domains.add(value)
-                        "mtu" -> value.toIntOrNull()?.let { mtu = it }
-                    }
-                }
-            }
-            return NetworkConfig(dir, network, inviter, bundle, addresses, routes, dns, domains, mtu)
-        }
-
-        private fun cidr(s: String): CidrAddr? {
-            val parts = s.split("/")
-            if (parts.size != 2) return null
-            val prefix = parts[1].toIntOrNull() ?: return null
-            return CidrAddr(parts[0], prefix)
+            val f = File(dir, "vpn.conf").takeIf { it.isFile } ?: return NetworkConfig(dir)
+            val kv = confLines(f.readLines())
+            fun all(k: String) = kv.filter { it.first == k }.map { it.second }
+            return NetworkConfig(
+                dir,
+                network = all("network").lastOrNull(),
+                inviter = all("inviter").lastOrNull(),
+                bundleUrl = all("bundle").lastOrNull(),
+                addresses = all("address").mapNotNull(CidrAddr::parse),
+                routes = all("route").mapNotNull(CidrAddr::parse),
+                dnsServers = all("dns"),
+                searchDomains = all("domain"),
+                mtu = all("mtu").lastOrNull()?.toIntOrNull() ?: 1400,
+            )
         }
     }
 }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
@@ -24,7 +24,7 @@ class TincCtl(private val dir: File) {
 
     // Node name -> reachable, from `dump nodes` (status bit 4).
     fun nodes(): Map<String, Boolean> = converse(REQ_DUMP_NODES).orEmpty()
-        .mapNotNull { it.split(' ') }
+        .map { it.split(' ') }
         .filter { it.size > 12 }
         .associate { it[2] to ((it[12].toIntOrNull(16) ?: 0) and 0x10 != 0) }
 
@@ -44,12 +44,11 @@ class TincCtl(private val dir: File) {
                 r.readLine() ?: return null
                 r.readLine() ?: return null
                 sock.outputStream.write("18 $req\n".toByteArray())
+                // Dump rows have many fields, the final `18 <req> <result>` three.
                 val out = mutableListOf<String>()
-                while (true) {
-                    val line = r.readLine() ?: return null
-                    out.add(line)
-                    if (line.split(' ').size <= 3) break
-                }
+                do {
+                    out.add(r.readLine() ?: return null)
+                } while (out.last().split(' ').size > 3)
                 out
             }
         } catch (e: java.io.IOException) {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
@@ -11,6 +11,7 @@ import java.io.InputStreamReader
 class TincCtl(private val dir: File) {
     companion object {
         const val REQ_STOP = 0
+        const val REQ_RELOAD = 1
         const val REQ_DUMP_NODES = 3
         const val REQ_RETRY = 10
     }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincrVpnService.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincrVpnService.kt
@@ -57,6 +57,8 @@ class TincrVpnService : VpnService() {
         fdServer.serveOnce()
         watchNetwork(config)
         running = true
+        thread(name = "tincr-bundle") { BundleJob.refresh(config) }
+        BundleJob.schedule(this)
     }
 
     // Retry: consent may land just after service start.

--- a/android/app/src/main/res/xml/network_security.xml
+++ b/android/app/src/main/res/xml/network_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Bundles go over https. Cleartext only for loopback and the emulator host (tests). -->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/android/app/src/test/kotlin/io/thalheim/tincr/BundleTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/BundleTest.kt
@@ -44,10 +44,18 @@ class BundleTest {
         val dir = netDir()
         val n = Bundle.install(
             NetworkConfig.load(dir),
-            tgz("hosts/gate" to "Address = 1.2.3.4\n", "./eve" to "Address = 5.6.7.8\n", "README.md" to "x").inputStream(),
+            tgz(
+                "hosts/gate" to "Address = 1.2.3.4\nEd25519PublicKey = a\n",
+                "./eve" to "-----BEGIN RSA PUBLIC KEY-----\nx\n",
+                "README.md" to "x",
+                "README" to "not a host file\n",
+                "doc/deep/gate" to "Ed25519PublicKey = nested\n",
+                "big" to "Ed25519PublicKey = b\n" + "x".repeat(70_000),
+            ).inputStream(),
         )
         assertEquals(2, n)
         assertEquals(listOf("eve", "gate", "phone"), File(dir, "hosts").list()!!.sorted())
+        assertEquals("Address = 1.2.3.4\nEd25519PublicKey = a\n", File(dir, "hosts/gate").readText())
         assertEquals("Ed25519PublicKey = mine\n", File(dir, "hosts/phone").readText())
         assertEquals(false, File(dir, "hosts.new").exists() || File(dir, "hosts.old").exists())
     }

--- a/android/app/src/test/kotlin/io/thalheim/tincr/BundleTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/BundleTest.kt
@@ -1,0 +1,71 @@
+package io.thalheim.tincr
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.GZIPOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class BundleTest {
+    private fun tgz(vararg files: Pair<String, String>): ByteArray {
+        val out = ByteArrayOutputStream()
+        GZIPOutputStream(out).use { gz ->
+            for ((name, body) in files) {
+                val hdr = ByteArray(512)
+                name.toByteArray().copyInto(hdr, 0)
+                "0000644".toByteArray().copyInto(hdr, 100)
+                String.format("%011o", body.length).toByteArray().copyInto(hdr, 124)
+                hdr[156] = '0'.code.toByte()
+                "ustar".toByteArray().copyInto(hdr, 257)
+                "        ".toByteArray().copyInto(hdr, 148)
+                String.format("%06o", hdr.sumOf { it.toInt() and 0xFF }).toByteArray().copyInto(hdr, 148)
+                gz.write(hdr)
+                gz.write(body.toByteArray())
+                gz.write(ByteArray((512 - body.length % 512) % 512))
+            }
+            gz.write(ByteArray(1024))
+        }
+        return out.toByteArray()
+    }
+
+    private fun netDir(): File {
+        val dir = Files.createTempDirectory("bundle").toFile()
+        File(dir, "tinc.conf").writeText("Name = phone\n")
+        File(dir, "hosts").mkdirs()
+        File(dir, "hosts/phone").writeText("Ed25519PublicKey = mine\n")
+        File(dir, "hosts/stale").writeText("gone after update\n")
+        return dir
+    }
+
+    @Test
+    fun replacesHostsButKeepsOwn() {
+        val dir = netDir()
+        val n = Bundle.install(
+            NetworkConfig.load(dir),
+            tgz("hosts/gate" to "Address = 1.2.3.4\n", "./eve" to "Address = 5.6.7.8\n", "README.md" to "x").inputStream(),
+        )
+        assertEquals(2, n)
+        assertEquals(listOf("eve", "gate", "phone"), File(dir, "hosts").list()!!.sorted())
+        assertEquals("Ed25519PublicKey = mine\n", File(dir, "hosts/phone").readText())
+        assertEquals(false, File(dir, "hosts.new").exists() || File(dir, "hosts.old").exists())
+    }
+
+    @Test
+    fun bundleOverridesStaleOwnEntry() {
+        val dir = netDir()
+        Bundle.install(NetworkConfig.load(dir), tgz("phone" to "Ed25519PublicKey = registry\n").inputStream())
+        // Local copy wins so a pending key change is not reverted.
+        assertEquals("Ed25519PublicKey = mine\n", File(dir, "hosts/phone").readText())
+    }
+
+    @Test
+    fun emptyBundleKeepsHosts() {
+        val dir = netDir()
+        assertThrows(java.io.IOException::class.java) {
+            Bundle.install(NetworkConfig.load(dir), tgz("README.md" to "nothing").inputStream())
+        }
+        assertEquals(listOf("phone", "stale"), File(dir, "hosts").list()!!.sorted())
+    }
+}

--- a/android/app/src/test/kotlin/io/thalheim/tincr/JoinTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/JoinTest.kt
@@ -1,5 +1,6 @@
 package io.thalheim.tincr
 
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
@@ -33,7 +34,7 @@ class JoinTest {
         """.trimIndent().lines()
         assertEquals(
             "network mesh\ninviter gate\naddress 10.243.42.42/16\nroute 10.243.0.0/16\nroute 42::/16\n",
-            Join.vpnConf(data),
+            Join.fromInvitation(File("."), data).render(),
         )
     }
 
@@ -45,12 +46,12 @@ class JoinTest {
             Name = gate
             Address = 10.243.0.1
         """.trimIndent().lines()
-        val e = assertThrows(JoinError::class.java) { Join.vpnConf(data) }
-        assertEquals("Peer address 10.243.0.1 lies inside routed 10.243.0.0/16.", e.message)
+        val e = assertThrows(JoinError::class.java) { Join.fromInvitation(File("."), data).render() }
+        assertEquals("Peer address 10.243.0.1 lies inside routed 10.243.42.42/16.", e.message)
     }
 
     @Test
     fun missingIfconfigIsRefused() {
-        assertThrows(JoinError::class.java) { Join.vpnConf(listOf("Name = phone")) }
+        assertThrows(JoinError::class.java) { Join.fromInvitation(File("."), listOf("Name = phone")) }
     }
 }


### PR DESCRIPTION
`BundleUrl = https://...tar.gz` in the invitation is fetched on VPN start and daily (ETag), unpacked into hosts.new/, own host file kept, directory swapped, tincd reloaded. Also folds the config tokenizers for vpn.conf, tinc.conf and invitation data into one.