### PR TITLE
nix: move dev-only inputs into dev/ behind flake-compat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "nix"
+    directory: "/dev"
+    schedule:
+      interval: "weekly"

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,0 +1,88 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1788782697,
+        "narHash": "sha256-vwpEIlx5cfHs4OlmFaA6bd0UgWlil6eiebI6sVh8ci4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "36a0cdd15b062a8e6b529cf6e1a15fd4a26210b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixbot": {
+      "inputs": {
+        "nixpkgs": [],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788711868,
+        "narHash": "sha256-3L5I6n6kNqc6YIxJKpg9iUr3KQjRFy+eEI7ID86/Ym8=",
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "rev": "25df5fb2bc2128f302b42677104a42b7879801db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixbot": "nixbot",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788682297,
+        "narHash": "sha256-QJUlZv8IA/nB3sXyIsOEmrs6NHjmDDqpb4HJztiIkSw=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "9074e9b4c6bc31d7986ccf4e22d18af70e5508da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": []
+      },
+      "locked": {
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,0 +1,16 @@
+# Development-only inputs. The root flake loads this through flake-compat
+# so that consumers of tincr lock nothing but nixpkgs and crane.
+# Update with `nix flake update --flake ./dev`.
+{
+  inputs = {
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "";
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "";
+    nixbot.url = "github:Mic92/nixbot";
+    nixbot.inputs.nixpkgs.follows = "";
+    nixbot.inputs.treefmt-nix.follows = "treefmt-nix";
+  };
+
+  outputs = inputs: inputs;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -15,27 +15,6 @@
         "type": "github"
       }
     },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1788433075,
-        "narHash": "sha256-8j/0mNhbRbJQ7KyGxtS3vEeNhT5cK8NEM2ZQr03uOrU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "c957e2d0e505ad7be04c7f2f2f3d7885fb9e242c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1788316716,
@@ -55,46 +34,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1788394718,
-        "narHash": "sha256-Dyr++cx/ODeP4T4PdaaW7gX8TH9IQs7kScZdi9aMn2s=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "bf25c45e974ab01bf46bc9fdca0f8b2fde66ae27",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786901030,
-        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,26 +3,25 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     crane.url = "github:ipetkov/crane";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      treefmt-nix,
       crane,
-      fenix,
     }:
     let
+      # Formatter, android toolchain and CI effects live in dev/ so that
+      # consumers lock only the inputs above.
+      dev =
+        (import (fetchTarball {
+          url = "https://github.com/NixOS/flake-compat/archive/5edf11c44bc78a0d334f6334cdaf7d60d732daab.tar.gz";
+          sha256 = "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=";
+        }) { src = ./dev; }).outputs;
+      inherit (dev) treefmt-nix nixbot;
+      fenixFor = pkgs: import dev.fenix { inherit pkgs; };
       systems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -68,7 +67,7 @@
             in
             pkgs'.callPackage ./nix/tincd-android.nix {
               craneLib = crane.mkLib pkgs';
-              fenix = fenix.packages.${system};
+              fenix = fenixFor pkgs';
             };
           tincd-android-x86_64 = self.packages.${system}.tincd-android.override {
             target = "x86_64-linux-android";
@@ -88,7 +87,7 @@
         }
         // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
           android = (androidPkgsFor system).callPackage ./nix/devshell-android.nix {
-            fenix = fenix.packages.${system};
+            fenix = fenixFor (androidPkgsFor system);
           };
         }
       );


### PR DESCRIPTION
Consumers lock only nixpkgs and crane. treefmt-nix, fenix and nixbot come from dev/flake.lock, loaded with flake-compat and fed the root nixpkgs. Dependabot watches /dev too.