### PR TITLE
invite: show the phone link and a QR code on terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,7 +1322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1468,6 +1474,7 @@ dependencies = [
  "getrandom 0.4.3",
  "libc",
  "nix",
+ "qrcode",
  "rand_core 0.10.1",
  "rsa",
  "serde",

--- a/crates/tinc-tools/Cargo.toml
+++ b/crates/tinc-tools/Cargo.toml
@@ -42,6 +42,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 base64 = "0.23.1"
 rsa = { version = "0.10.0-rc.18", features = ["sha2"] }
+qrcode = { version = "0.14", default-features = false }
 subtle.workspace = true
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/tinc-tools/src/bin/tinc.rs
+++ b/crates/tinc-tools/src/bin/tinc.rs
@@ -477,9 +477,9 @@ fn cmd_fsck(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError>
     }
 }
 
-/// Prints the URL to stdout (the only thing on stdout, so
-/// `tinc invite alice | mail alice@example` works). Warnings to
-/// stderr.
+/// The bare `HOST/SLUG` goes to stdout so `tinc invite alice | mail`
+/// and C `tinc join` keep working. On a terminal the app link and a QR
+/// code follow on stderr.
 fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdError> {
     let mut replace = false;
     let mut env = Vec::new();
@@ -528,8 +528,14 @@ fn cmd_invite(paths: &Paths, g: &Globals, args: &[String]) -> Result<(), CmdErro
         }
     }
 
-    // The URL is the secret. stdout only.
     println!("{}", *r.url);
+    if io::stdout().is_terminal() {
+        let link = cmd::invite::app_link(&r.url);
+        eprintln!(
+            "\nPhone: open {link} or scan\n\n{}",
+            cmd::invite::qr_utf8(&link)
+        );
+    }
     Ok(())
 }
 

--- a/crates/tinc-tools/src/cmd/invite.rs
+++ b/crates/tinc-tools/src/cmd/invite.rs
@@ -52,6 +52,7 @@ use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, SystemTime};
 
+use qrcode::{EcLevel, QrCode, render::unicode::Dense1x2};
 use rand_core::Rng;
 use tinc_conf::Config;
 use tinc_crypto::b64;
@@ -242,10 +243,12 @@ pub fn invite(
     let slug = Zeroizing::new(build_slug(pubkey, &cookie));
     let url = Zeroizing::new(format!("{address}/{}", *slug));
 
+    let link = Zeroizing::new(app_link(&url));
     let mut hook_env: Vec<(&str, &str)> = vec![
         ("NAME", &myname),
         ("NODE", invitee),
         ("INVITATION_URL", &url),
+        ("INVITATION_LINK", &link),
     ];
     hook_env.extend(netname.map(|n| ("NETNAME", n)));
     hook_env.extend(headers.replace.as_deref().map(|k| ("REPLACE", k)));
@@ -258,6 +261,27 @@ pub fn invite(
     }
 
     Ok(InviteResult { url, key_is_new })
+}
+
+/// What phones open or scan. `tinc join` accepts it too.
+#[must_use]
+pub fn app_link(url: &str) -> String {
+    format!("tinc://join/{url}")
+}
+
+/// QR code as UTF-8 half blocks, dark on light with a quiet zone, for
+/// terminals.
+#[must_use]
+pub fn qr_utf8(data: &str) -> String {
+    QrCode::with_error_correction_level(data, EcLevel::L).map_or_else(
+        |_| String::new(),
+        |c| {
+            c.render::<Dense1x2>()
+                .dark_color(Dense1x2::Light)
+                .light_color(Dense1x2::Dark)
+                .build()
+        },
+    )
 }
 
 /// Lines a hook appended after the original body belong to the invitee,
@@ -858,8 +882,8 @@ mod tests {
         let script = cd.confbase().join("invitation-created");
         fs::write(
             &script,
-            "#!/bin/sh\nprintf 'Subnet = 10.0.0.7\\n# %s %s %s\\n' \
-             \"$NODE\" \"$NAME\" \"$INVITATION_URL\" >> \"$INVITATION_FILE\"\n",
+            "#!/bin/sh\nprintf 'Subnet = 10.0.0.7\\n# %s %s %s %s\\n' \
+             \"$NODE\" \"$NAME\" \"$INVITATION_URL\" \"$INVITATION_LINK\" >> \"$INVITATION_FILE\"\n",
         )
         .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
@@ -870,11 +894,17 @@ mod tests {
         let chunk1 = body.split(SEPARATOR).next().unwrap();
         assert!(
             chunk1.ends_with(&format!(
-                "Subnet = 10.0.0.7\n# bob alice {}\n",
+                "Subnet = 10.0.0.7\n# bob alice {0} tinc://join/{0}\n",
                 r.url.as_str()
             )),
             "{body}"
         );
+    }
+
+    #[test]
+    fn qr_renders_link() {
+        let q = qr_utf8("tinc://join/host.example/x");
+        assert!(q.lines().count() > 10 && q.contains('█'), "{q}");
     }
 
     /// A failing hook aborts the invite and leaves no invitation behind,

--- a/crates/tinc-tools/src/cmd/join/tests.rs
+++ b/crates/tinc-tools/src/cmd/join/tests.rs
@@ -34,6 +34,8 @@ fn url_ok() {
             ("[::1]:655/",          "::1",          "655"),
             // IPv6 no port
             ("[fe80::1]/",          "fe80::1",      "655"),
+            // phone link form from `tinc invite`
+            ("tinc://join/host.example:1234/", "host.example", "1234"),
         ];
     for (prefix, host, port) in cases {
         let url = format!("{prefix}{slug}");

--- a/crates/tinc-tools/src/cmd/join/url.rs
+++ b/crates/tinc-tools/src/cmd/join/url.rs
@@ -25,6 +25,8 @@ pub struct ParsedUrl {
 /// descriptively.
 #[must_use]
 pub fn parse_url(url: &str) -> Option<ParsedUrl> {
+    // The phone link form printed next to the bare URL.
+    let url = url.strip_prefix("tinc://join/").unwrap_or(url);
     let slash = url.find('/')?;
     let (addr_part, slug_with_slash) = url.split_at(slash);
     let slug = &slug_with_slash[1..]; // skip '/'

--- a/man/tinc.8
+++ b/man/tinc.8
@@ -148,6 +148,9 @@ followed by
 Generate an invitation URL for
 .Ar NODE
 and print it to stdout.
+On a terminal the
+.Li tinc://join/
+link for the phone app and a QR code of it follow on stderr.
 Each
 .Fl e
 is stored in the invitation and exported to the


### PR DESCRIPTION
stdout still prints the bare `HOST/SLUG`. On a tty, stderr additionally shows `tinc://join/HOST/SLUG` and a UTF-8 QR code (qrcode crate, no extra deps). Hooks receive `INVITATION_LINK`, and `tinc join` strips the `tinc://join/` prefix.
