### PR TITLE
android: supervise tincd, autostart, and actionable error messages

### DIFF
--- a/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
+++ b/android/app/src/androidTest/kotlin/io/thalheim/tincr/MeshTest.kt
@@ -89,7 +89,7 @@ class MeshTest {
     @Test
     fun meshComesUp() {
         freshDirs(withPhone = true)
-        gate = TincdRunner(ctx, NetworkConfig.load(gateDir)).also { it.start() }
+        gate = TincdRunner(File(ctx.applicationInfo.nativeLibraryDir, "libtincd.so"), gateDir).also { it.start {} }
         bringUpAndCheck()
     }
 
@@ -99,13 +99,13 @@ class MeshTest {
     fun joinThenMesh() {
         freshDirs(withPhone = false)
         File(gateDir, "hosts/phone").delete()
-        gate = TincdRunner(ctx, NetworkConfig.load(gateDir)).also { it.start() }
+        gate = TincdRunner(File(ctx.applicationInfo.nativeLibraryDir, "libtincd.so"), gateDir).also { it.start {} }
         poll(10_000, "gate control socket") { File(gateDir, "tincd.pid").isFile }
 
         val url = tinc(gateDir, "invite", "phone").lines().first { it.startsWith("127.0.0.1:") }.trim()
         val inv = File(gateDir, "invitations").listFiles()!!.single { it.name != "ed25519_key.priv" }
         // Stands in for an invitation-created hook on the inviter.
-        val port = serveBundle(mapOf("extra" to "Subnet = 10.243.9.9/32\n"))
+        val port = serveBundle(mapOf("extra" to "Subnet = 10.243.9.9/32\nEd25519PublicKey = ${"A".repeat(43)}\n"))
         inv.writeText(
             inv.readText().replaceFirst(
                 "#--",

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,14 @@
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="fullSensor"
             tools:replace="screenOrientation" />
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
         <service
             android:name=".BundleJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
@@ -45,6 +53,9 @@
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
+            <meta-data
+                android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
+                android:value="true" />
         </service>
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/io/thalheim/tincr/BootReceiver.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/BootReceiver.kt
@@ -1,0 +1,16 @@
+package io.thalheim.tincr
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.VpnService
+import java.io.File
+
+// Restores the VPN after boot/update if it was on and consent still holds.
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val wanted = File(context.filesDir, "networks/default/${TincrVpnService.WANTED}")
+        if (!wanted.isFile || VpnService.prepare(context) != null) return
+        context.startForegroundService(Intent(context, TincrVpnService::class.java))
+    }
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Bundle.kt
@@ -31,7 +31,8 @@ object Bundle {
             when (val code = conn.responseCode) {
                 HttpURLConnection.HTTP_NOT_MODIFIED -> return false
                 HttpURLConnection.HTTP_OK -> {}
-                else -> throw java.io.IOException("bundle fetch: HTTP $code")
+                HttpURLConnection.HTTP_NOT_FOUND -> throw java.io.IOException("HTTP 404, the bundle URL from the invitation no longer exists")
+                else -> throw java.io.IOException("HTTP $code")
             }
             val n = conn.inputStream.use { install(config, it) }
             conn.getHeaderField("ETag")?.let { etagFile.writeText(it) }
@@ -57,9 +58,11 @@ object Bundle {
         }
         if (n == 0) {
             fresh.deleteRecursively()
-            throw java.io.IOException("bundle has no host files")
+            throw java.io.IOException("archive contains no host files")
         }
+        // Never lose the ConnectTo peer, or the next start cannot dial anyone.
         val hosts = File(dir, "hosts")
+        config.inviter?.let { File(hosts, it).takeIf { f -> f.isFile && !File(fresh, it).exists() }?.copyTo(File(fresh, it)) }
         config.name?.let { own -> File(hosts, own).takeIf { it.isFile }?.copyTo(File(fresh, own), overwrite = true) }
         val old = File(dir, "hosts.old").apply { deleteRecursively() }
         hosts.renameTo(old)

--- a/android/app/src/main/kotlin/io/thalheim/tincr/BundleJob.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/BundleJob.kt
@@ -8,16 +8,21 @@ import android.content.ComponentName
 import android.content.Context
 import android.util.Log
 import java.io.File
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import kotlin.concurrent.thread
 
-// Daily hosts/ refresh. Also run on every VPN start.
+// Daily hosts/ refresh, also kicked on VPN start and app open.
 class BundleJob : JobService() {
     companion object {
         private const val ID = 1
+        private val executor = Executors.newSingleThreadExecutor { r -> Thread(r, "tincr-bundle").apply { isDaemon = true } }
+
+        @Volatile
+        var lastProblem: Problem? = null
+            private set
 
         fun schedule(context: Context) {
-            val js = context.getSystemService(JobScheduler::class.java)
+            val js = context.getSystemService(JobScheduler::class.java) ?: return
             if (js.getPendingJob(ID) != null) return
             js.schedule(
                 JobInfo.Builder(ID, ComponentName(context, BundleJob::class.java))
@@ -28,14 +33,19 @@ class BundleJob : JobService() {
             )
         }
 
-        @Synchronized
-        fun refresh(config: NetworkConfig) {
-            try {
-                if (Bundle.update(config) && TincrVpnService.running) {
-                    TincCtl(config.dir).request(TincCtl.REQ_RELOAD)
+        // Serialised on one thread so two refreshes never race on hosts.new/.
+        fun kick(context: Context, config: NetworkConfig, done: () -> Unit = {}) {
+            val url = config.bundleUrl ?: return done()
+            executor.execute {
+                try {
+                    if (Bundle.update(config) && Vpn.running) TincCtl(config.dir).request(TincCtl.REQ_RELOAD)
+                    lastProblem = null
+                } catch (e: Exception) {
+                    Log.w("tincr", "bundle: ${e.message}")
+                    lastProblem = Problems.bundle(url, e)
+                } finally {
+                    done()
                 }
-            } catch (e: Exception) {
-                Log.w("tincr", "bundle update failed: ${e.message}")
             }
         }
     }
@@ -43,10 +53,7 @@ class BundleJob : JobService() {
     override fun onStartJob(params: JobParameters): Boolean {
         val config = NetworkConfig.load(File(filesDir, "networks/default"))
         if (config.bundleUrl == null) return false
-        thread(name = "tincr-bundle") {
-            refresh(config)
-            jobFinished(params, false)
-        }
+        kick(this, config) { jobFinished(params, false) }
         return true
     }
 

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Join.kt
@@ -20,8 +20,12 @@ object Join {
     }
 
     fun run(context: Context, dir: File, link: String) {
-        val url = parseLink(link) ?: throw JoinError("This is not an invitation link.")
+        val url = parseLink(link) ?: throw JoinError(
+            if (link.trim().startsWith("http")) "This is a web link, not an invitation. Invitations look like server/…48 characters."
+            else "This is not an invitation link. It should look like server/…48 characters.",
+        )
         val tinc = File(context.applicationInfo.nativeLibraryDir, "libtinc.so")
+        if (!tinc.canExecute()) throw JoinError("This install is incomplete (libtinc.so missing). Reinstall the app.")
         val tmp = File(dir.parentFile, dir.name + ".join")
         tmp.deleteRecursively()
         tmp.mkdirs()
@@ -29,13 +33,30 @@ object Join {
             val p = ProcessBuilder(tinc.absolutePath, "--batch", "-c", tmp.absolutePath, "join", url)
                 .redirectErrorStream(true).start()
             val out = p.inputStream.bufferedReader().readText()
-            if (p.waitFor() != 0) throw JoinError(out.lines().lastOrNull { it.isNotBlank() } ?: "join failed")
+            if (p.waitFor() != 0) throw JoinError(explain(url, out))
             finish(tmp)
             dir.deleteRecursively()
             if (!tmp.renameTo(dir)) throw JoinError("cannot move config into place")
         } finally {
             tmp.deleteRecursively()
         }
+    }
+
+    // Turn tinc's stderr into something a person can act on, raw text kept below.
+    private fun explain(url: String, out: String): String {
+        val host = url.substringBeforeLast('/')
+        val last = out.lines().lastOrNull { it.isNotBlank() }.orEmpty()
+        val hint = when {
+            "looking up" in out || "resolve" in out ->
+                "Can’t find the server $host. Check your internet connection, or ask whoever sent this whether the address is right."
+            "Could not connect" in out || "timed out" in out || "Connection refused" in out ->
+                "The server $host does not answer. It may be down or this network blocks it. Try mobile data, then ask the sender."
+            "Peer has an invalid key" in out || "Invalid invitation" in out || "not valid" in out ->
+                "The server does not recognise this invitation. Each invitation works once and expires. Ask for a new one."
+            "already exists" in out -> "This phone already joined. To start over, clear the app’s storage in Android settings."
+            else -> "Joining failed."
+        }
+        return "$hint\n\n($last)"
     }
 
     private fun finish(dir: File) {

--- a/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/MainActivity.kt
@@ -28,14 +28,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.concurrent.thread
 import androidx.compose.runtime.rememberCoroutineScope
 import java.io.File
 
 class MainActivity : ComponentActivity() {
     private val netDir get() = File(filesDir, "networks/default")
     private val consent = registerForActivityResult(StartActivityForResult()) {
-        if (it.resultCode == RESULT_OK) startVpn()
+        if (it.resultCode == RESULT_OK) startVpn() else Vpn.problem = Problems.consentMissing()
     }
 
     // Non-null shows the join screen. Set by deep link, QR scan or the button.
@@ -54,12 +53,10 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    // People open the app when something is off or to look someone up,
-    // so bring hosts/ up to date right then. A conditional GET, 304 mostly.
+    // People open the app when something is off, so refresh hosts/ now.
     override fun onResume() {
         super.onResume()
-        val config = NetworkConfig.load(netDir)
-        if (config.bundleUrl != null) thread(name = "tincr-bundle") { BundleJob.refresh(config) }
+        BundleJob.kick(this, NetworkConfig.load(netDir))
     }
 
     @Composable
@@ -67,20 +64,19 @@ class MainActivity : ComponentActivity() {
         var tab by remember { mutableStateOf(Tab.Home) }
         var advanced by remember { mutableStateOf(false) }
         var log by remember { mutableStateOf("") }
-        var state by remember { mutableStateOf(homeState(emptyMap(), false)) }
+        var state by remember { mutableStateOf(homeState(emptyMap(), Vpn.phase)) }
         var joined by remember { mutableStateOf(File(netDir, "tinc.conf").isFile) }
         var joinBusy by remember { mutableStateOf(false) }
         var joinError by remember { mutableStateOf<String?>(null) }
         val scope = rememberCoroutineScope()
         LaunchedEffect(Unit) {
             while (true) {
-                val running = TincrVpnService.running
+                val phase = Vpn.phase
                 val (nodes, tail) = withContext(Dispatchers.IO) {
-                    val f = File(netDir, "tincd.log")
-                    (if (running) TincCtl(netDir).nodes() else emptyMap()) to
-                        (if (f.isFile) f.readLines().takeLast(200).joinToString("\n") else "(no log)")
+                    (if (phase == Phase.Running) TincCtl(netDir).nodes() else emptyMap()) to
+                        TincdRunner.logTail(netDir, 200).ifEmpty { "(no log)" }
                 }
-                state = homeState(nodes, running)
+                state = homeState(nodes, phase)
                 log = tail
                 delay(1000)
             }
@@ -115,24 +111,28 @@ class MainActivity : ComponentActivity() {
         }
         MainScreen(
             state, tab, onTab = { tab = it },
-            onToggle = { if (TincrVpnService.running) stop() else prepareAndStart() },
-            onHelpReport = { sendHelpReport(log) },
+            onToggle = { if (Vpn.phase == Phase.Off) prepareAndStart() else stop() },
+            onHelpReport = { sendHelpReport(state, log) },
             onSettings = { advanced = true },
         )
     }
 
-    // Connected once any peer is reachable, so the ring does not turn
-    // green on a daemon that is up but alone.
-    private fun homeState(nodes: Map<String, Boolean>, running: Boolean): HomeState {
+    // Connected only once a peer is reachable, not merely when tincd is up.
+    private fun homeState(nodes: Map<String, Boolean>, phase: Phase): HomeState {
         val cfg = NetworkConfig.load(netDir)
         val self = cfg.name
         val devices = cfg.hosts.map { Device(it, "", online = nodes[it] == true, self = it == self) }
         val anyPeer = devices.any { it.online && !it.self }
         return HomeState(
             network = cfg.network ?: "tincr",
-            link = if (!running) Link.Off else if (anyPeer) Link.Connected else Link.Connecting,
+            link = when {
+                phase == Phase.Off || phase == Phase.Stopping -> Link.Off
+                anyPeer -> Link.Connected
+                else -> Link.Connecting
+            },
             devices = devices,
             inviter = cfg.inviter ?: "the person who invited you",
+            notice = Vpn.problem ?: BundleJob.lastProblem,
         )
     }
 
@@ -143,10 +143,19 @@ class MainActivity : ComponentActivity() {
         )
     }
 
-    private fun sendHelpReport(log: String) {
+    private fun sendHelpReport(state: HomeState, log: String) {
+        val cfg = NetworkConfig.load(netDir)
+        val text = buildString {
+            append("tincr ").append(runCatching { packageManager.getPackageInfo(packageName, 0).versionName }.getOrNull()).append('\n')
+            append("Android ").append(android.os.Build.VERSION.RELEASE).append(" (").append(android.os.Build.MODEL).append(")\n")
+            append("node ").append(cfg.name).append(" network ").append(cfg.network).append(" via ").append(cfg.inviter).append('\n')
+            append("state ").append(Vpn.phase).append(", ").append(state.onlineCount).append('/').append(state.devices.size).append(" reachable\n")
+            state.notice?.let { append("\nProblem: ").append(it.title).append('\n').append(it.detail).append('\n') }
+            append("\n--- tincd.log (last 200 lines) ---\n").append(log)
+        }
         val send = Intent(Intent.ACTION_SEND).setType("text/plain")
-            .putExtra(Intent.EXTRA_SUBJECT, "tincr help report")
-            .putExtra(Intent.EXTRA_TEXT, log)
+            .putExtra(Intent.EXTRA_SUBJECT, "tincr help report from ${cfg.name}")
+            .putExtra(Intent.EXTRA_TEXT, text)
         startActivity(Intent.createChooser(send, "Send help report"))
     }
 
@@ -155,7 +164,12 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun prepareAndStart() {
-        val ask = VpnService.prepare(this)
+        val ask = try {
+            VpnService.prepare(this)
+        } catch (e: IllegalStateException) {
+            Vpn.problem = Problems.consentMissing().copy(detail = "prepare: ${e.message}")
+            return
+        }
         if (ask != null) consent.launch(ask) else startVpn()
     }
 

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Problems.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Problems.kt
@@ -1,0 +1,76 @@
+package io.thalheim.tincr
+
+import java.io.File
+
+// Every failure the app can detect maps to one of these so people either
+// fix it themselves or forward something an operator can act on.
+object Problems {
+    fun notJoined() = Problem(
+        "Not set up yet",
+        "Open the invitation link or scan the code you were given.",
+    )
+
+    fun consentMissing() = Problem(
+        "VPN permission needed",
+        "Android asks once whether tincr may create a VPN. Tap Connect and allow it. " +
+            "If another VPN app is set to always-on, turn that off in Android settings first.",
+    )
+
+    fun revoked() = Problem(
+        "Another VPN took over",
+        "Android allows one VPN at a time. Tap Connect to switch back to tincr.",
+    )
+
+    fun establishFailed(e: Throwable?) = Problem(
+        "Android refused the VPN interface",
+        "Restart the phone. If it keeps happening send a help report.",
+        "VpnService.establish(): ${e?.let { "${it.javaClass.simpleName}: ${it.message}" } ?: "returned null 5x"}",
+    )
+
+    fun badConfig(what: String) = Problem(
+        "The saved network settings are damaged",
+        "Ask for a new invitation and join again. Your old entry will be replaced.",
+        what,
+    )
+
+    fun binaryMissing(f: File) = Problem(
+        "This install is incomplete",
+        "Reinstall tincr from where you got it. The VPN engine is missing from the app package.",
+        "not executable: $f",
+    )
+
+    fun crashed(rc: Int, logTail: String, restartingInMs: Long) = Problem(
+        "Connection engine stopped, retrying",
+        "tincr restarts it by itself. If this stays for minutes, send a help report.",
+        "tincd exit $rc, restart in ${restartingInMs / 1000}s\n$logTail",
+    )
+
+    fun crashLoop(rc: Int, logTail: String) = Problem(
+        "Can’t keep the connection engine running",
+        "Send a help report so the person who invited you can see why.",
+        "tincd exit $rc repeatedly\n$logTail",
+    )
+
+    fun noInternet() = Problem(
+        "No internet connection",
+        "The network will reconnect by itself when you’re back online.",
+    )
+
+    fun peerUnreachable(inviter: String, seconds: Long, logTail: String) = Problem(
+        "Can’t reach $inviter",
+        "Your internet works but $inviter’s server does not answer. It may be down, " +
+            "or this Wi-Fi blocks VPNs. Try mobile data. If that does not help, tell $inviter.",
+        "no meta connection after ${seconds}s\n$logTail",
+    )
+
+    fun bundle(url: String, e: Throwable) = Problem(
+        "Device list could not be updated",
+        "Connecting still works with the list from last time. tincr retries daily and whenever you open the app.",
+        "GET $url: ${e.javaClass.simpleName}: ${e.message}",
+    )
+
+    fun newPhone(inviter: String) = Problem(
+        "This looks like a new phone",
+        "Keys do not move between phones. Ask $inviter for a fresh invitation.",
+    )
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincCtl.kt
@@ -2,56 +2,65 @@ package io.thalheim.tincr
 
 import android.net.LocalSocket
 import android.net.LocalSocketAddress
-import java.io.BufferedReader
 import java.io.File
-import java.io.InputStreamReader
+import java.io.IOException
 
-// Control-socket client: greeting `0 ^COOKIE 0` (two reply
-// lines), then `18 <req>` acked with `18 <req> <result>`.
+// Control socket client. Greeting `0 ^COOKIE 0` (two reply lines), then
+// `18 <req>` answered by rows and a final `18 <req> <result>`.
 class TincCtl(private val dir: File) {
     companion object {
         const val REQ_STOP = 0
         const val REQ_RELOAD = 1
         const val REQ_DUMP_NODES = 3
+        const val REQ_DUMP_CONNECTIONS = 6
         const val REQ_RETRY = 10
+        private const val TIMEOUT_MS = 3000
+        private const val MAX_ROWS = 100_000
     }
 
-    private fun cookie(): String? =
-        File(dir, "tincd.pid").takeIf { it.isFile }
-            ?.readText()?.split(Regex("\\s+"))?.getOrNull(1)
+    fun request(req: Int): Boolean = converse(req)?.lastOrNull()?.startsWith("18 $req 0") == true
 
-    fun request(req: Int): Boolean = converse(req)?.let { it.lastOrNull()?.startsWith("18 $req 0") } ?: false
-
-    // Node name -> reachable, from `dump nodes` (status bit 4).
+    // name -> reachable (status bit 4). Empty when the daemon is not up.
     fun nodes(): Map<String, Boolean> = converse(REQ_DUMP_NODES).orEmpty()
         .map { it.split(' ') }
-        .filter { it.size > 12 }
+        .filter { it.size > 12 && it[0] == "18" }
         .associate { it[2] to ((it[12].toIntOrNull(16) ?: 0) and 0x10 != 0) }
 
-    // Lines up to and including the `18 <req> ...` terminator.
+    // Active meta connections, excluding the control connection itself.
+    fun metaConnections(): Int? = converse(REQ_DUMP_CONNECTIONS)
+        ?.map { it.split(' ') }
+        ?.count { it.size > 5 && it[0] == "18" && it[2] != "<control>" }
+
+    private fun cookie(): String? = File(dir, "tincd.pid").takeIf { it.isFile }
+        ?.runCatching { readText() }?.getOrNull()
+        ?.split(Regex("\\s+"))?.getOrNull(1)?.takeIf { it.length == 64 }
+
     private fun converse(req: Int): List<String>? {
         val cookie = cookie() ?: return null
         return try {
             LocalSocket().use { sock ->
                 sock.connect(
-                    LocalSocketAddress(
-                        File(dir, "tincd.socket").absolutePath,
-                        LocalSocketAddress.Namespace.FILESYSTEM,
-                    )
+                    LocalSocketAddress(File(dir, "tincd.socket").absolutePath, LocalSocketAddress.Namespace.FILESYSTEM),
                 )
-                val r = BufferedReader(InputStreamReader(sock.inputStream))
-                sock.outputStream.write("0 ^$cookie 0\n".toByteArray())
+                sock.soTimeout = TIMEOUT_MS
+                val r = sock.inputStream.bufferedReader()
+                val w = sock.outputStream
+                w.write("0 ^$cookie 0\n".toByteArray())
+                w.flush()
                 r.readLine() ?: return null
-                r.readLine() ?: return null
-                sock.outputStream.write("18 $req\n".toByteArray())
-                // Dump rows have many fields, the final `18 <req> <result>` three.
-                val out = mutableListOf<String>()
-                do {
-                    out.add(r.readLine() ?: return null)
-                } while (out.last().split(' ').size > 3)
-                out
+                if (r.readLine()?.startsWith("4 ") != true) return null
+                w.write("18 $req\n".toByteArray())
+                w.flush()
+                val out = ArrayList<String>()
+                while (out.size < MAX_ROWS) {
+                    val line = r.readLine() ?: return null
+                    out.add(line)
+                    val f = line.split(' ')
+                    if (f.size <= 3 && f[0] == "18" && f.getOrNull(1) == "$req") return out
+                }
+                null
             }
-        } catch (e: java.io.IOException) {
+        } catch (_: IOException) {
             null
         }
     }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincdRunner.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincdRunner.kt
@@ -1,55 +1,69 @@
 package io.thalheim.tincr
 
-import android.content.Context
 import android.util.Log
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-// Runs libtincd.so from nativeLibraryDir against a config dir.
-class TincdRunner(context: Context, private val config: NetworkConfig) {
-    private val binary = File(context.applicationInfo.nativeLibraryDir, "libtincd.so")
-    private val confDir = config.dir
+// One libtincd.so process. Not restartable, make a new one.
+class TincdRunner(private val binary: File, private val confDir: File) {
+    @Volatile
     private var process: Process? = null
 
-    fun start() {
-        reapOrphan()
+    @Volatile
+    private var stopping = false
+
+    // onExit runs on a background thread when tincd died on its own.
+    fun start(onExit: (Int) -> Unit) {
+        check(process == null) { "TincdRunner started twice" }
+        reapOrphan(confDir)
         val p = ProcessBuilder(
             binary.absolutePath,
             "--config", confDir.absolutePath,
             "--pidfile", File(confDir, "tincd.pid").absolutePath,
             "--logfile", File(confDir, "tincd.log").absolutePath,
             "--debug", "5",
+            "--no-detach",
         ).redirectErrorStream(true).start()
         process = p
-        Thread {
-            p.inputStream.bufferedReader().forEachLine { Log.i("tincd", it) }
-        }.apply { isDaemon = true }.start()
+        Thread({
+            runCatching { p.inputStream.bufferedReader().forEachLine { Log.i("tincd", it) } }
+            val rc = runCatching { p.waitFor() }.getOrDefault(-1)
+            if (!stopping) onExit(rc)
+        }, "tincd-wait").apply { isDaemon = true }.start()
     }
 
     fun stop() {
+        stopping = true
+        val p = process ?: return
         TincCtl(confDir).request(TincCtl.REQ_STOP)
-        process?.let {
-            if (!it.waitFor(5, TimeUnit.SECONDS)) {
-                it.destroy()
-                if (!it.waitFor(2, TimeUnit.SECONDS)) it.destroyForcibly()
-            }
+        if (!p.waitFor(5, TimeUnit.SECONDS)) {
+            p.destroy()
+            if (!p.waitFor(2, TimeUnit.SECONDS)) p.destroyForcibly()
         }
-        process = null
     }
 
-    // Exec'd daemons outlive the app process. Stop leftovers or
-    // the port bind fails.
-    private fun reapOrphan() {
-        val pid = File(confDir, "tincd.pid").takeIf { it.isFile }
-            ?.readText()?.split(Regex("\\s+"))?.firstOrNull()?.toIntOrNull()
-            ?: return
-        if (!File("/proc/$pid").isDirectory) return
-        Log.i("tincr", "stopping orphaned tincd (pid $pid)")
-        TincCtl(confDir).request(TincCtl.REQ_STOP)
-        for (i in 0 until 50) {
-            if (!File("/proc/$pid").isDirectory) return
-            Thread.sleep(100)
+    companion object {
+        // Exec'd daemons outlive the app process and hold the port.
+        fun reapOrphan(confDir: File) {
+            val pid = File(confDir, "tincd.pid").takeIf { it.isFile }
+                ?.runCatching { readText() }?.getOrNull()
+                ?.split(Regex("\\s+"))?.firstOrNull()?.toIntOrNull()
+                ?: return
+            if (pid <= 1 || pid == android.os.Process.myPid() || !File("/proc/$pid").isDirectory) return
+            val cmd = runCatching { File("/proc/$pid/cmdline").readText() }.getOrDefault("")
+            if (!cmd.contains("libtincd.so")) return
+            Log.i("tincr", "stopping orphaned tincd (pid $pid)")
+            TincCtl(confDir).request(TincCtl.REQ_STOP)
+            repeat(50) {
+                if (!File("/proc/$pid").isDirectory) return
+                Thread.sleep(100)
+            }
+            android.os.Process.sendSignal(pid, 9)
         }
-        android.os.Process.sendSignal(pid, 9)
+
+        fun logTail(confDir: File, lines: Int = 20): String =
+            File(confDir, "tincd.log").takeIf { it.isFile }
+                ?.runCatching { useLines { s -> s.toList().takeLast(lines).joinToString("\n") } }
+                ?.getOrNull().orEmpty()
     }
 }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TincrVpnService.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TincrVpnService.kt
@@ -9,85 +9,216 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.VpnService
+import android.os.Handler
+import android.os.HandlerThread
 import android.os.ParcelFileDescriptor
 import android.util.Log
 import java.io.File
-import kotlin.concurrent.thread
 
+// All state lives on one HandlerThread. Binder callbacks, tincd exit and
+// network events only post to it, so there is no locking and no ordering
+// surprises between start, stop, crash and revoke.
 class TincrVpnService : VpnService() {
     companion object {
         const val ACTION_STOP = "io.thalheim.tincr.STOP"
+        const val WANTED = "vpn.wanted"
         private const val TAG = "tincr"
         private const val CHANNEL = "tincr-vpn"
         private const val TUN_SOCKET = "tincr-tun"
-
-        @Volatile
-        var running = false
-            private set
+        private const val STABLE_MS = 60_000L
+        private const val MAX_CRASHES = 8
+        private const val PEER_GRACE_MS = 20_000L
     }
 
-    private var tun: ParcelFileDescriptor? = null
-    private var daemon: TincdRunner? = null
-    private var netCallback: ConnectivityManager.NetworkCallback? = null
+    private class Session(
+        val config: NetworkConfig,
+        val tun: ParcelFileDescriptor,
+        val fdServer: TunFdServer,
+        var daemon: TincdRunner? = null,
+        var crashes: Int = 0,
+        var since: Long = 0,
+    )
 
+    private lateinit var thread: HandlerThread
+    private lateinit var handler: Handler
+    private val peerCheck = Runnable { checkPeer() }
+    private var session: Session? = null
+    private var netCallback: ConnectivityManager.NetworkCallback? = null
+    private val netDir by lazy { File(filesDir, "networks/default") }
+    private val binary by lazy { File(applicationInfo.nativeLibraryDir, "libtincd.so") }
+
+    override fun onCreate() {
+        super.onCreate()
+        thread = HandlerThread("tincr-vpn").apply { start() }
+        handler = Handler(thread.looper)
+    }
+
+    // Null intent: START_STICKY restart or always-on VPN.
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_STOP) {
-            stopVpn()
-            stopSelf()
+            wanted(false)
+            handler.post { down(); stopSelf() }
             return START_NOT_STICKY
         }
         startForeground(1, notification())
-        thread(name = "tincr-start") { startVpn() }
+        wanted(true)
+        handler.post { up() }
         return START_STICKY
     }
 
-    private fun startVpn() {
-        if (daemon != null) return
-        val config = NetworkConfig.load(File(filesDir, "networks/default"))
-        val tun = establishWithRetry(config) ?: run {
-            Log.e(TAG, "establish() returned null (VPN permission revoked?)")
+    override fun onRevoke() {
+        wanted(false)
+        handler.post {
+            down()
+            Vpn.problem = Problems.revoked()
             stopSelf()
-            return
         }
-        this.tun = tun
+    }
 
-        val fdServer = TunFdServer(TUN_SOCKET, tun.fileDescriptor)
-        daemon = TincdRunner(this, config).also { it.start() }
-        // tincd connects to @tincr-tun and receives the tun fd.
-        fdServer.serveOnce()
-        watchNetwork(config)
-        running = true
-        thread(name = "tincr-bundle") { BundleJob.refresh(config) }
+    override fun onDestroy() {
+        handler.post { down() }
+        thread.quitSafely()
+        thread.join(10_000)
+        super.onDestroy()
+    }
+
+    private fun wanted(on: Boolean) {
+        val f = File(netDir, WANTED)
+        runCatching { if (on) { f.parentFile?.mkdirs(); f.writeText("") } else f.delete() }
+    }
+
+    private fun fail(p: Problem) {
+        Log.e(TAG, "${p.title}: ${p.detail}")
+        Vpn.problem = p
+        down()
+        wanted(false)
+        stopSelf()
+    }
+
+    private fun up() {
+        if (session != null) return
+        Vpn.phase = Phase.Starting
+        Vpn.problem = null
+        if (!File(netDir, "tinc.conf").isFile) return fail(Problems.notJoined())
+        if (!binary.canExecute()) return fail(Problems.binaryMissing(binary))
+        val config = NetworkConfig.load(netDir)
+        if (config.addresses.isEmpty()) return fail(Problems.badConfig("vpn.conf has no address line"))
+        if (config.name == null) return fail(Problems.badConfig("tinc.conf has no Name"))
+        if (!File(netDir, "ed25519_key.priv").isFile) return fail(Problems.newPhone(config.inviter ?: "the person who invited you"))
+        val tun = establish(config) ?: return
+        val fdServer = try {
+            TunFdServer(TUN_SOCKET, tun.fileDescriptor)
+        } catch (e: java.io.IOException) {
+            runCatching { tun.close() }
+            return fail(Problems.establishFailed(e))
+        }
+        session = Session(config, tun, fdServer)
+        spawn()
+        watchNetwork()
+        Vpn.phase = Phase.Running
+        armPeerCheck()
+        BundleJob.kick(this, config)
         BundleJob.schedule(this)
     }
 
-    // Retry: consent may land just after service start.
-    private fun establishWithRetry(config: NetworkConfig): ParcelFileDescriptor? {
+    private fun establish(config: NetworkConfig): ParcelFileDescriptor? {
+        var last: Throwable? = null
         repeat(5) { attempt ->
-            Builder()
-                .setSession("tincr")
-                .setMtu(config.mtu)
-                .apply {
-                    config.addresses.forEach { addAddress(it.address, it.prefix) }
-                    config.routes.forEach { addRoute(it.address, it.prefix) }
-                    config.dnsServers.forEach { addDnsServer(it) }
-                    config.searchDomains.forEach { addSearchDomain(it) }
+            try {
+                Builder()
+                    .setSession(config.network ?: "tincr")
+                    .setMtu(config.mtu)
+                    .apply {
+                        config.addresses.forEach { addAddress(it.address, it.prefix) }
+                        config.routes.forEach { addRoute(it.address, it.prefix) }
+                        config.dnsServers.forEach { addDnsServer(it) }
+                        config.searchDomains.forEach { addSearchDomain(it) }
+                    }
+                    .establish()?.let { return it }
+                // null: consent not (yet) granted.
+                if (prepare(this) != null) {
+                    fail(Problems.consentMissing())
+                    return null
                 }
-                .establish()?.let { return it }
-            Log.w(TAG, "establish() null, attempt $attempt")
+            } catch (e: IllegalArgumentException) {
+                fail(Problems.badConfig("VpnService.Builder: ${e.message}"))
+                return null
+            } catch (e: RuntimeException) {
+                last = e
+            }
+            Log.w(TAG, "establish() failed, attempt $attempt")
             Thread.sleep(1000)
         }
+        fail(Problems.establishFailed(last))
         return null
     }
 
-    // On network change tell tincd to redial past its backoff.
-    private fun watchNetwork(config: NetworkConfig) {
+    private fun spawn() {
+        val s = session ?: return
+        val runner = TincdRunner(binary, s.config.dir)
+        s.daemon = runner
+        s.since = System.currentTimeMillis()
+        try {
+            runner.start { rc -> handler.post { exited(runner, rc) } }
+        } catch (e: java.io.IOException) {
+            fail(Problems.binaryMissing(binary).copy(detail = "exec: ${e.message}"))
+        }
+    }
+
+    private fun exited(runner: TincdRunner, rc: Int) {
+        val s = session?.takeIf { it.daemon === runner } ?: return
+        s.daemon = null
+        val tail = TincdRunner.logTail(s.config.dir)
+        if (System.currentTimeMillis() - s.since > STABLE_MS) s.crashes = 0
+        if (++s.crashes > MAX_CRASHES) return fail(Problems.crashLoop(rc, tail))
+        val wait = 1000L shl minOf(s.crashes - 1, 5)
+        Log.w(TAG, "tincd exited with $rc, restart in ${wait}ms")
+        Vpn.problem = Problems.crashed(rc, tail, wait)
+        handler.postDelayed({
+            if (session === s && s.daemon == null) {
+                spawn()
+                armPeerCheck()
+            }
+        }, wait)
+    }
+
+    // After a grace period with internet but no meta connection, say so.
+    private fun checkPeer() {
+        val s = session ?: return
+        val conns = TincCtl(s.config.dir).metaConnections() ?: return
+        val online = getSystemService(ConnectivityManager::class.java).let { cm ->
+            cm.getNetworkCapabilities(cm.activeNetwork)?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+        }
+        Vpn.problem = when {
+            conns > 0 -> null
+            !online -> Problems.noInternet()
+            else -> Problems.peerUnreachable(
+                s.config.inviter ?: "the server", (System.currentTimeMillis() - s.since) / 1000,
+                TincdRunner.logTail(s.config.dir),
+            )
+        }
+        if (conns == 0) armPeerCheck()
+    }
+
+    private fun armPeerCheck() {
+        handler.removeCallbacks(peerCheck)
+        handler.postDelayed(peerCheck, PEER_GRACE_MS)
+    }
+
+    private fun watchNetwork() {
+        if (netCallback != null) return
         val cm = getSystemService(ConnectivityManager::class.java)
         val cb = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                thread(name = "tincr-retry") {
-                    TincCtl(config.dir).request(TincCtl.REQ_RETRY)
+                handler.post {
+                    val s = session ?: return@post
+                    TincCtl(s.config.dir).request(TincCtl.REQ_RETRY)
+                    armPeerCheck()
                 }
+            }
+
+            override fun onLost(network: Network) {
+                handler.post { if (session != null) checkPeer() }
             }
         }
         cm.registerNetworkCallback(
@@ -100,28 +231,23 @@ class TincrVpnService : VpnService() {
         netCallback = cb
     }
 
-    private fun stopVpn() {
-        running = false
-        netCallback?.let {
-            getSystemService(ConnectivityManager::class.java).unregisterNetworkCallback(it)
-        }
+    private fun down() {
+        val s = session ?: run { Vpn.phase = Phase.Off; return }
+        Vpn.phase = Phase.Stopping
+        session = null
+        handler.removeCallbacksAndMessages(null)
+        netCallback?.let { runCatching { getSystemService(ConnectivityManager::class.java).unregisterNetworkCallback(it) } }
         netCallback = null
-        daemon?.stop()
-        daemon = null
-        tun?.close()
-        tun = null
-    }
-
-    override fun onDestroy() {
-        stopVpn()
-        super.onDestroy()
+        s.daemon?.let { runCatching { it.stop() }.onFailure { e -> Log.w(TAG, "stop: ${e.message}") } }
+        s.daemon = null
+        s.fdServer.close()
+        runCatching { s.tun.close() }
+        Vpn.phase = Phase.Off
     }
 
     private fun notification(): Notification {
         val nm = getSystemService(NotificationManager::class.java)
-        nm.createNotificationChannel(
-            NotificationChannel(CHANNEL, "VPN", NotificationManager.IMPORTANCE_LOW)
-        )
+        nm.createNotificationChannel(NotificationChannel(CHANNEL, "VPN", NotificationManager.IMPORTANCE_LOW))
         return Notification.Builder(this, CHANNEL)
             .setContentTitle("tincr")
             .setSmallIcon(android.R.drawable.ic_lock_lock)

--- a/android/app/src/main/kotlin/io/thalheim/tincr/TunFdServer.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/TunFdServer.kt
@@ -1,21 +1,43 @@
 package io.thalheim.tincr
 
 import android.net.LocalServerSocket
+import android.net.LocalSocket
+import android.net.LocalSocketAddress
+import android.util.Log
+import java.io.Closeable
 import java.io.FileDescriptor
+import java.io.IOException
+import kotlin.concurrent.thread
 
-// Sends the tun fd via SCM_RIGHTS to tincd (Device = @NAME).
-class TunFdServer(name: String, private val fd: FileDescriptor) {
+// Hands the tun fd via SCM_RIGHTS to each tincd that connects to @NAME.
+class TunFdServer(private val name: String, private val fd: FileDescriptor) : Closeable {
     private val server = LocalServerSocket(name)
 
-    fun serveOnce() {
-        try {
-            server.accept().use {
-                it.setFileDescriptorsForSend(arrayOf(fd))
-                it.outputStream.write(1)
-                it.outputStream.flush()
+    @Volatile
+    private var closed = false
+
+    init {
+        thread(name = "tincr-tunfd", isDaemon = true) {
+            while (!closed) {
+                try {
+                    server.accept().use {
+                        if (closed) return@use
+                        it.setFileDescriptorsForSend(arrayOf(fd))
+                        it.outputStream.write(1)
+                        it.outputStream.flush()
+                    }
+                } catch (e: IOException) {
+                    if (!closed) Log.w("tincr", "tun fd handover: ${e.message}")
+                }
             }
-        } finally {
-            server.close()
         }
+    }
+
+    // close() alone does not wake accept().
+    override fun close() {
+        if (closed) return
+        closed = true
+        runCatching { server.close() }
+        runCatching { LocalSocket().use { it.connect(LocalSocketAddress(name)) } }
     }
 }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/Vpn.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/Vpn.kt
@@ -1,0 +1,21 @@
+package io.thalheim.tincr
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+enum class Phase { Off, Starting, Running, Stopping }
+
+// What the user sees when something is wrong: an instruction first, the
+// technical detail below it for passing on.
+data class Problem(val title: String, val body: String, val detail: String = "")
+
+// Single source of truth for the UI. Written by the service thread only.
+object Vpn {
+    var phase by mutableStateOf(Phase.Off)
+        internal set
+    var problem by mutableStateOf<Problem?>(null)
+        internal set
+
+    val running get() = phase == Phase.Running
+}

--- a/android/app/src/main/kotlin/io/thalheim/tincr/ui/Model.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/ui/Model.kt
@@ -1,18 +1,8 @@
 package io.thalheim.tincr.ui
 
-enum class Link { Connected, Connecting, Off }
+import io.thalheim.tincr.Problem
 
-// Degraded states are phrased as instructions, never diagnoses.
-enum class Notice(val title: String, val body: String) {
-    NoInternet(
-        "No internet connection",
-        "The network will reconnect by itself when you’re back online.",
-    ),
-    NewPhone(
-        "This looks like a new phone",
-        "Ask the person who invited you for a fresh invitation.",
-    ),
-}
+enum class Link { Connected, Connecting, Off }
 
 data class Device(
     val name: String,
@@ -26,7 +16,7 @@ data class HomeState(
     val link: Link,
     val devices: List<Device>,
     val inviter: String,
-    val notice: Notice? = null,
+    val notice: Problem? = null,
 ) {
     val onlineCount get() = devices.count { it.online }
 }

--- a/android/app/src/main/kotlin/io/thalheim/tincr/ui/Screens.kt
+++ b/android/app/src/main/kotlin/io/thalheim/tincr/ui/Screens.kt
@@ -40,6 +40,10 @@ import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,7 +52,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import io.thalheim.tincr.Problem
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -268,13 +274,23 @@ private fun DeviceRow(d: Device) {
 }
 
 @Composable
-private fun NoticeBanner(n: Notice) {
+private fun NoticeBanner(n: Problem) {
+    var open by remember { mutableStateOf(false) }
     Column(
         Modifier.padding(top = 16.dp).fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp)).background(Palette.amberSoft).padding(14.dp),
+            .clip(RoundedCornerShape(14.dp)).background(Palette.amberSoft)
+            .clickable(enabled = n.detail.isNotEmpty()) { open = !open }.padding(14.dp),
     ) {
         Text(n.title, color = Palette.amberInk, fontSize = 15.sp, fontWeight = FontWeight.Bold)
         Text(n.body, color = Palette.amberInk.copy(alpha = .85f), fontSize = 14.sp)
+        if (n.detail.isNotEmpty()) {
+            Text(
+                if (open) n.detail else "Tap for details to pass on",
+                color = Palette.amberInk.copy(alpha = .7f), fontSize = 12.sp,
+                fontFamily = if (open) FontFamily.Monospace else null,
+                modifier = Modifier.padding(top = 6.dp),
+            )
+        }
     }
 }
 

--- a/android/app/src/test/kotlin/io/thalheim/tincr/ScreenshotTest.kt
+++ b/android/app/src/test/kotlin/io/thalheim/tincr/ScreenshotTest.kt
@@ -10,7 +10,6 @@ import io.thalheim.tincr.ui.HomeState
 import io.thalheim.tincr.ui.JoinScreen
 import io.thalheim.tincr.ui.Link
 import io.thalheim.tincr.ui.MainScreen
-import io.thalheim.tincr.ui.Notice
 import io.thalheim.tincr.ui.OnboardingScreen
 import io.thalheim.tincr.ui.Tab
 import io.thalheim.tincr.ui.TincrTheme
@@ -62,9 +61,11 @@ class ScreenshotTest {
     @Test fun homeConnecting() = shot("2_home_connecting") { main(family.copy(link = Link.Connecting), Tab.Home) }
     @Test fun devices() = shot("3_devices") { main(family, Tab.Devices) }
     @Test fun devicesNoInternet() =
-        shot("3_devices_no_internet") { main(family.copy(notice = Notice.NoInternet), Tab.Devices) }
+        shot("3_devices_no_internet") { main(family.copy(notice = Problems.noInternet()), Tab.Devices) }
+    @Test fun homePeerUnreachable() =
+        shot("2_home_peer_unreachable") { main(family.copy(link = Link.Connecting, notice = Problems.peerUnreachable("Dad", 40, "Trying to connect to gate (203.0.113.5 port 655)\nTimeout from gate")), Tab.Home) }
     @Test fun homeNewPhone() =
-        shot("2_home_new_phone") { main(family.copy(link = Link.Off, notice = Notice.NewPhone), Tab.Home) }
+        shot("2_home_new_phone") { main(family.copy(link = Link.Off, notice = Problems.newPhone("Dad")), Tab.Home) }
     @Test fun help() = shot("4_help") { main(family, Tab.Help) }
     @Test fun advanced() = shot("5_advanced") {
         AdvancedScreen("tincd 0.1.0 starting\nListening on 0.0.0.0 port 12655\nConnected to gate", onBack = {})


### PR DESCRIPTION
Stacked on #92.

- Service state on one HandlerThread. tincd started with `--no-detach`, restarted on crash with backoff on the same tun fd, crash loop gives up with a message.
- BootReceiver (boot + package replaced) restarts the VPN if it was on, `SUPPORTS_ALWAYS_ON`, `onRevoke` handled.
- `Problem` catalogue: banner with instruction + expandable technical detail, also part of the help report (version, Android, node, state, log tail).
- TincCtl with socket timeout and bounded reads, TunFdServer serves every tincd instance, bundle refreshes serialised on one executor.
